### PR TITLE
TMDM-12317 [Studio] Record files obtained from a server export can be overwritten in some cases

### DIFF
--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ExportDataContentProcess.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ExportDataContentProcess.java
@@ -258,7 +258,7 @@ public class ExportDataContentProcess extends AbstractDataContentProcess {
 
         protected void writeString(String exportFolder, String outputStr, String filename) {
 
-            File f = new File(exportFolder + "/" + filename);//$NON-NLS-1$
+            File f = new File(exportFolder + "/" + filename + ".txt");//$NON-NLS-1$
 
             if (!f.getParentFile().exists()) {
                 f.getParentFile().mkdir();


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

On Windows, if the file name include dot at the end of a filename, it will be removed by system, so it can overwrite file without dot at the end of filename.

**What is the new behavior?**

This fixing will add a suffix to the end of the file name, so it won't overwrite even the file name includes a dot at the end.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
