### PR TITLE
TMDM-12543 Change FK to reference in datamodel editor while FK icon not disappeared in ER editor

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
@@ -171,6 +171,7 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
             if (newRef != null) {
                 decl.setResolvedElementDeclaration(newRef);
                 decl.setTypeDefinition(null);
+                decl.setAnnotation(null);
                 Element elem = decl.getElement();
                 if (elem.getAttributes().getNamedItem("type") != null) {
                     elem.getAttributes().removeNamedItem("type");//$NON-NLS-1$
@@ -266,9 +267,11 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
     /********************************
      * Listener to input dialog
      */
+    @Override
     public void widgetDefaultSelected(SelectionEvent e) {
     }
 
+    @Override
     public void widgetSelected(SelectionEvent e) {
         if (dialog.getReturnCode() == -1) {
             return; // there was a validation error

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/detailtabs/sections/handlers/ElementWrapperCommitHandler.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/detailtabs/sections/handlers/ElementWrapperCommitHandler.java
@@ -110,6 +110,7 @@ public class ElementWrapperCommitHandler extends CommitHandler<ElementWrapper> {
             if (newRef != null) {
                 decl.setResolvedElementDeclaration(newRef);
                 decl.setTypeDefinition(null);
+                decl.setAnnotation(null);
                 Element elem = decl.getElement();
                 if (elem.getAttributes().getNamedItem("type") != null) {
                     elem.getAttributes().removeNamedItem("type");//$NON-NLS-1$

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/providers/XSDTreeLabelProvider.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/providers/XSDTreeLabelProvider.java
@@ -367,13 +367,14 @@ public class XSDTreeLabelProvider extends LabelProvider implements ITreePathLabe
             XSDParticle xsdParticle = (XSDParticle) obj;
 
             XSDTerm xsdTerm = xsdParticle.getTerm();
-            if (xsdTerm instanceof XSDElementDeclaration) {
+            XSDParticleContent content = xsdParticle.getContent();
+            if (content instanceof XSDElementDeclaration) {
                 // get Type of Parent Group
                 List<Object> realKeyInfos = Util.getRealKeyInfos(entity, xsdParticle);
                 if (realKeyInfos != null && realKeyInfos.size() > 0) {
                     return ImageCache.getCreatedImage(EImage.PRIMARYKEY.getPath());
                 }
-                if (XSDUtil.hasFKInfo((XSDElementDeclaration) xsdTerm)) {
+                if (XSDUtil.hasFKInfo((XSDElementDeclaration) content)) {
                     return ImageCache.getCreatedImage(EImage.FK_OBJ.getPath());
                 }
 


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
Change FK to reference in datamodel editor while FK icon not disappeared in ER editor
link: https://jira.talendforge.org/browse/TMDM-12543

**What is the new behavior?**
The FK icon disappear after change FK to reference


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
