### PR TITLE
TMDM-12664  Modify reference element to simple element will show error.

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
@@ -178,27 +178,14 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
                 }
                 decl.updateElement();
             } else if (ref != null) {
-                // fliu
-                // no more element declarations --> we create a new Declaration with String simpleType definition
-                // instead
-                // FIXME: dereferecning and element is buggy
-
-                XSDFactory factory = XSDSchemaBuildingTools.getXSDFactory();
-                XSDElementDeclaration newD = factory.createXSDElementDeclaration();
-                newD.setName(this.elementName);
-                newD.updateElement();
                 XSDSimpleTypeDefinition stringType = ((SchemaTreeContentProvider) page.getTreeViewer().getContentProvider())
                         .getXsdSchema().getSchemaForSchema()
                         .resolveSimpleTypeDefinition(XSDConstants.SCHEMA_FOR_SCHEMA_URI_2001, "string"); //$NON-NLS-1$
-
-                newD.setTypeDefinition(stringType);
-                if (selParticle.getContainer() instanceof XSDModelGroup) {
-                    XSDModelGroup group = ((XSDModelGroup) selParticle.getContainer());
-                    ((XSDModelGroup) selParticle.getContainer()).getContents().remove(selParticle);
-                    selParticle = factory.createXSDParticle();
-                    selParticle.setContent(newD);
-                    group.getContents().add(selParticle);
-                }
+                decl.setResolvedElementDeclaration(decl);
+                selParticle.setTerm(decl);
+                decl.setTypeDefinition(stringType);
+                decl.updateElement();
+                selParticle.updateElement();
             }
 
             if (Util.changeElementTypeToSequence(decl, maxOccurs) == Status.CANCEL_STATUS) {


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

https://jira.talendforge.org/browse/TMDM-12664
Fixed showing error dialog when modifying reference element to simple element.

**What is the new behavior?**
No error dialog pops when modify reference element to simple element.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
