### PR TITLE
TMDM-12686  [Impact Analysis] Always display result in English while switching to other language

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/HttpClientUtil.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/HttpClientUtil.java
@@ -454,10 +454,10 @@ public class HttpClientUtil {
     public static String invokeModelService(String protocol, String host, String port, String contextPath, String username,
             String password, String modelName, String xsd, boolean isUpdate, Boolean force) throws XtentisException {
         try {
-            String url = protocol + host + ":" + port + contextPath + "/services/rest/system/models/" + modelName + "?lang=" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                    + I18nUtil.getCurrentNL();
-
-            if (force != null) {
+            String url = protocol + host + ":" + port + contextPath + "/services/rest/system/models/" + modelName; //$NON-NLS-1$//$NON-NLS-2$
+            if (!isUpdate) {
+                url += "?lang=" + I18nUtil.getCurrentNL(); //$NON-NLS-1$
+            } else if (force != null) {
                 url += "?force=" + force.toString(); //$NON-NLS-1$
             }
             HttpUriRequest request = null;


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
Can not run recreate table when switch to other language
link: https://jira.talendforge.org/browse/TMDM-12686

About bug: when invoke "recreate table" ,the studio will append  parameter "?force=True" at end of request URL, it causes two "?" character at URL(another is "?lang"),when this request arrives server the second parameter "force" is ignored, because it needn't "lang" parameter when "recreate table" so remove it to fix this issue.

**What is the new behavior?**
It can send recreate table PUT request successfully.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
