### PR TITLE
TMDM-12878 tMDMRestInput can not retrieve xml pattern data

### DIFF
--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMConnection/tMDMConnection_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMConnection/tMDMConnection_java.xml
@@ -140,10 +140,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMDelete/tMDMDelete_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMDelete/tMDMDelete_java.xml
@@ -230,10 +230,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMOutput/tMDMOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMOutput/tMDMOutput_java.xml
@@ -448,10 +448,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMReadConf/tMDMReadConf_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMReadConf/tMDMReadConf_java.xml
@@ -241,10 +241,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMRouteRecord/tMDMRouteRecord_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMRouteRecord/tMDMRouteRecord_java.xml
@@ -152,10 +152,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMSP/tMDMSP_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMSP/tMDMSP_java.xml
@@ -177,10 +177,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMViewSearch/tMDMViewSearch_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMViewSearch/tMDMViewSearch_java.xml
@@ -223,10 +223,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />

--- a/main/plugins/org.talend.designer.components.tomprovider/components/tMDMWriteConf/tMDMWriteConf_java.xml
+++ b/main/plugins/org.talend.designer.components.tomprovider/components/tMDMWriteConf/tMDMWriteConf_java.xml
@@ -266,10 +266,9 @@
                     BundleID=""
                     />
                  <IMPORT
-                    NAME="stax2-api-3.1.4"
-                    MODULE="stax2-api-3.1.4.jar"
-                    MVN="mvn:org.talend.libraries/stax2-api-3.1.4/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/stax2-api-3.1.4.jar"
+                    NAME="stax2-api-4.1"
+                    MODULE="stax2-api-4.1.jar"
+                    MVN="mvn:org.codehaus.woodstox/stax2-api/4.1"
                     REQUIRED="true"
                     BundleID=""
                     />


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-12878
What is the current behavior? (You should also link to an open issue here)

What is the new behavior?
Version of woodstox-core is upgrade to 5.1.0 when doing TMDM-12490 Update cxf from 3.2.4 to 3.2.6 .
woodstox-core-5.1.0 is incompatible with stax2-api-3.1.4, need upgrade to stax2-api-4.1
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
