### PR TITLE
TMDM-11900 Update schema of UpdateReport, add 'UUID' field for standalone mode, additionally add acceptance for update data model condition operator.

### DIFF
--- a/main/plugins/org.talend.mdm.repository/plugin.xml
+++ b/main/plugins/org.talend.mdm.repository/plugin.xml
@@ -619,6 +619,14 @@
                   name="Update Operator MigrationTask"
                   version="6.2.0">
             </projecttask>
+            <projecttask
+                  beforeLogon="true"
+                  breaks="7.2.1"
+                  class="org.talend.mdm.repository.core.migrate.DataModelMigrationTask"
+                  id="org.talend.mdm.repository.core.migrate.DataModelMigrationTask"
+                  name="Data Model MigrationTask"
+                  version="7.2.1">
+            </projecttask>
       
    </extension>
    <extension

--- a/main/plugins/org.talend.mdm.repository/resources/system/datamodel/UpdateReport_0.1.xsd
+++ b/main/plugins/org.talend.mdm.repository/resources/system/datamodel/UpdateReport_0.1.xsd
@@ -2,7 +2,6 @@
 	<xsd:element abstract="false" name="Update" nillable="false" type="Update">
 		<xsd:unique name="Update">
 			<xsd:selector xpath="."/>
-			<xsd:field xpath="Source"/>
 			<xsd:field xpath="TimeInMillis"/>
 		</xsd:unique>
 	</xsd:element>
@@ -11,6 +10,7 @@
 			<xsd:element maxOccurs="1" minOccurs="0" name="UserName" nillable="true" type="xsd:string"/>
 			<xsd:element maxOccurs="1" minOccurs="1" name="Source" nillable="false" type="xsd:string"/>
 			<xsd:element maxOccurs="1" minOccurs="1" name="TimeInMillis" nillable="false" type="xsd:string"/>
+			<xsd:element maxOccurs="1" minOccurs="1" name="UUID" nillable="false" type="xsd:string"/>
 			<xsd:element maxOccurs="1" minOccurs="1" name="OperationType" nillable="false">
 				<xsd:simpleType>
 					<xsd:restriction base="xsd:string">

--- a/main/plugins/org.talend.mdm.repository/resources/system/datamodel/UpdateReport_0.1.xsd
+++ b/main/plugins/org.talend.mdm.repository/resources/system/datamodel/UpdateReport_0.1.xsd
@@ -2,6 +2,7 @@
 	<xsd:element abstract="false" name="Update" nillable="false" type="Update">
 		<xsd:unique name="Update">
 			<xsd:selector xpath="."/>
+			<xsd:field xpath="Source"/>
 			<xsd:field xpath="TimeInMillis"/>
 		</xsd:unique>
 	</xsd:element>

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/migrate/DataModelMigrationTask.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/migrate/DataModelMigrationTask.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -19,10 +19,6 @@ import org.talend.core.model.migration.AbstractItemMigrationTask;
 import org.talend.core.model.properties.Item;
 import org.talend.mdm.repository.ui.wizards.imports.UpdatorProvider;
 
-/**
- * @author sbliu
- *
- */
 public class DataModelMigrationTask extends AbstractItemMigrationTask {
 
     @Override

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/migrate/DataModelMigrationTask.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/migrate/DataModelMigrationTask.java
@@ -19,22 +19,22 @@ import org.talend.core.model.migration.AbstractItemMigrationTask;
 import org.talend.core.model.properties.Item;
 import org.talend.mdm.repository.ui.wizards.imports.UpdatorProvider;
 
-
 /**
- * created by liusongbo on Apr 18, 2016
+ * @author sbliu
  *
  */
-public class UpdateOperatorMigrationTask extends AbstractItemMigrationTask {
+public class DataModelMigrationTask extends AbstractItemMigrationTask {
 
+    @Override
     public Date getOrder() {
-        GregorianCalendar gc = new GregorianCalendar(2016, 4, 15, 0, 0, 0);
+        GregorianCalendar gc = new GregorianCalendar(2019, 3, 7, 0, 0, 0);
         return gc.getTime();
     }
 
     @Override
     public ExecutionResult execute(Item item) {
-        UpdatorProvider.instance().updateOperator(item);
-
+        UpdatorProvider.instance().updateDataModelSchema(item);
         return ExecutionResult.SUCCESS_NO_ALERT;
     }
+
 }

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/migrate/UpdateOperatorMigrationTask.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/migrate/UpdateOperatorMigrationTask.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -20,12 +20,9 @@ import org.talend.core.model.properties.Item;
 import org.talend.mdm.repository.ui.wizards.imports.UpdatorProvider;
 
 
-/**
- * created by liusongbo on Apr 18, 2016
- *
- */
 public class UpdateOperatorMigrationTask extends AbstractItemMigrationTask {
 
+    @Override
     public Date getOrder() {
         GregorianCalendar gc = new GregorianCalendar(2016, 4, 15, 0, 0, 0);
         return gc.getTime();

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
@@ -13,6 +13,7 @@
 package org.talend.mdm.repository.ui.wizards.imports;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import javax.xml.XMLConstants;
@@ -28,37 +29,31 @@ import org.talend.core.model.properties.ReferenceFileItem;
 import org.talend.mdm.repository.model.mdmproperties.WSDataModelItem;
 import org.talend.mdm.repository.utils.RepositoryResourceUtil;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import com.amalto.workbench.utils.IXMLConstants;
-import com.amalto.workbench.utils.Util;
-
 
 /**
- * created by liusongbo on Apr 14, 2016
+ * @author sbliu
  *
  */
-public class DatamodelOperatorUpdator implements IOperatorUpdator {
+public abstract class AbstractDataModelUpdator {
 
-    private static Logger log = Logger.getLogger(DatamodelOperatorUpdator.class);
+    private static Logger log = Logger.getLogger(AbstractDataModelUpdator.class);
 
-    @Override
-    public boolean updateConditionOperator(Item item) {
+    public boolean updateDatamodel(Item item) {
         boolean modified = false;
-        if(item != null && item instanceof WSDataModelItem) {
-            
+        if (item != null && item instanceof WSDataModelItem && accept(item)) {
             WSDataModelItem modelItem = (WSDataModelItem) item;
             EList<ReferenceFileItem> resources = modelItem.getReferenceResources();
             for (ReferenceFileItem fileItem : resources) {
                 if (fileItem.getExtension().equals("xsd")) { //$NON-NLS-1$
                     ByteArray content = fileItem.getContent();
-                    byte[] byteContent = content.getInnerContent();
-                    String xsdSchema = updateOperator(byteContent);
+                    String xsdSchema = doUpdation(content.getInnerContent());
                     if (xsdSchema != null) {
                         try {
-                            byteContent = xsdSchema.getBytes("utf-8"); //$NON-NLS-1$
+                            byte[] byteContent = xsdSchema.getBytes("utf-8"); //$NON-NLS-1$
                             content.setInnerContent(byteContent);
                             modelItem.getWsDataModel().setXsdSchema(new String(byteContent, "utf-8")); //$NON-NLS-1$
                         } catch (UnsupportedEncodingException e) {
@@ -71,6 +66,7 @@ public class DatamodelOperatorUpdator implements IOperatorUpdator {
                 }
             }
 
+
             if (modified) {
                 RepositoryResourceUtil.saveItem(item);
             }
@@ -79,51 +75,23 @@ public class DatamodelOperatorUpdator implements IOperatorUpdator {
         return modified;
     }
 
-    private String updateOperator(byte[] byteContent) {
-        String result = null;
-        if (byteContent != null) {
-
-            boolean modified = false;
-            try {
-                DocumentBuilder documentBuilder = getDocumentBuilder();
-                InputSource source = new InputSource(new ByteArrayInputStream(byteContent));
-                Document document = documentBuilder.parse(source);
-                NodeList appinfoTags = document.getElementsByTagName("xsd:appinfo"); //$NON-NLS-1$
-                int len = appinfoTags.getLength();
-                for (int i = 0; i < len; i++) {
-                    Node appItem = appinfoTags.item(i);
-                    Node sourceAttr = appItem.getAttributes().getNamedItem("source"); //$NON-NLS-1$
-                    if (sourceAttr.getNodeValue().equals("X_ForeignKey_Filter")) { //$NON-NLS-1$
-                        String content = appItem.getTextContent();
-                        if (content.contains("Strict Contains") || content.contains("Contains Text Of")) { //$NON-NLS-1$//$NON-NLS-2$
-                            content = content.replaceAll("Contains Text Of", "Contains"); //$NON-NLS-1$ //$NON-NLS-2$
-                            content = content.replaceAll("Strict Contains", "Contains"); //$NON-NLS-1$ //$NON-NLS-2$
-                            appItem.setTextContent(content);
-
-                            modified = true;
-                        }
-                    }
-                }
-
-                if (modified) {
-                    result = Util.nodeToString(document);
-                }
-
-            } catch (Exception e) {
-                log.error(e.getMessage(), e);
-            }
-        }
-
-        return result;
+    protected boolean accept(Item item) {
+        return true;
     }
 
-    private DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
+    protected abstract String doUpdation(byte[] byteContent);
+
+    protected Document getSchemaDocument(byte[] byteContent) throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         documentBuilderFactory.setFeature(IXMLConstants.DISALLOW_DOCTYPE_DECL, true);
         documentBuilderFactory.setNamespaceAware(true);
         documentBuilderFactory.setValidating(false);
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-        return documentBuilder;
+
+        InputSource source = new InputSource(new ByteArrayInputStream(byteContent));
+        Document document = documentBuilder.parse(source);
+        return document;
     }
+
 }

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
@@ -51,7 +51,7 @@ public abstract class AbstractDataModelUpdator {
                             content.setInnerContent(byteContent);
                             modelItem.getWsDataModel().setXsdSchema(new String(byteContent, "utf-8")); //$NON-NLS-1$
                         } catch (UnsupportedEncodingException e) {
-                            LOG.error("Encodes/Decodes string by 'utf-8' encoding failed", e); //$NON-NLS-1$
+                            LOG.error("Failed to Encodes/Decodes string by 'utf-8' encoding.", e); //$NON-NLS-1$
                         }
 
                         modified = true;
@@ -82,13 +82,13 @@ public abstract class AbstractDataModelUpdator {
             inputStream = new ByteArrayInputStream(byteContent);
             document = documentBuilder.parse(inputStream);
         } catch (Exception e) {
-            LOG.error("Parse input stream error", e); //$NON-NLS-1$
+            LOG.error("Failed to parse input stream.", e); //$NON-NLS-1$
         } finally {
             if (inputStream != null) {
                 try {
                     inputStream.close();
                 } catch (Exception e) {
-                    LOG.error("Close input stream error", e); //$NON-NLS-1$
+                    LOG.error("Failed to close input stream.", e); //$NON-NLS-1$
                 }
             }
         }

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
@@ -51,7 +51,7 @@ public abstract class AbstractDataModelUpdator {
                             content.setInnerContent(byteContent);
                             modelItem.getWsDataModel().setXsdSchema(new String(byteContent, "utf-8")); //$NON-NLS-1$
                         } catch (UnsupportedEncodingException e) {
-                            LOG.error(e.getMessage(), e);
+                            LOG.error("Encodes/Decodes string by 'utf-8' encoding failed", e); //$NON-NLS-1$
                         }
 
                         modified = true;
@@ -88,10 +88,11 @@ public abstract class AbstractDataModelUpdator {
                 try {
                     inputStream.close();
                 } catch (Exception e) {
-                    LOG.error("Close stream error", e); //$NON-NLS-1$
+                    LOG.error("Close input stream error", e); //$NON-NLS-1$
                 }
             }
         }
+
         return document;
     }
 

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/AbstractDataModelUpdator.java
@@ -51,7 +51,7 @@ public abstract class AbstractDataModelUpdator {
                             content.setInnerContent(byteContent);
                             modelItem.getWsDataModel().setXsdSchema(new String(byteContent, "utf-8")); //$NON-NLS-1$
                         } catch (UnsupportedEncodingException e) {
-                            LOG.error("Failed to Encodes/Decodes string by 'utf-8' encoding.", e); //$NON-NLS-1$
+                            LOG.error("Failed to encode/decode string by 'utf-8' encoding.", e); //$NON-NLS-1$
                         }
 
                         modified = true;

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -21,13 +21,9 @@ import org.w3c.dom.NodeList;
 import com.amalto.workbench.utils.Util;
 
 
-/**
- * created by liusongbo on Apr 14, 2016
- *
- */
 public class DataModelOperatorUpdator extends AbstractDataModelUpdator implements IOperatorUpdator {
 
-    private static Logger log = Logger.getLogger(DataModelOperatorUpdator.class);
+    private static final Logger LOG = Logger.getLogger(DataModelOperatorUpdator.class);
 
     @Override
     public boolean updateConditionOperator(Item item) {
@@ -35,7 +31,7 @@ public class DataModelOperatorUpdator extends AbstractDataModelUpdator implement
     }
 
     @Override
-    protected String doUpdation(byte[] byteContent) {
+    protected String doUpdate(byte[] byteContent) {
         return updateOperator(byteContent);
     }
 
@@ -74,7 +70,7 @@ public class DataModelOperatorUpdator extends AbstractDataModelUpdator implement
                 }
 
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOG.error("Update data model condition operator failed", e); //$NON-NLS-1$
             }
         }
 

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdator.java
@@ -70,7 +70,7 @@ public class DataModelOperatorUpdator extends AbstractDataModelUpdator implement
                 }
 
             } catch (Exception e) {
-                LOG.error("Update data model condition operator failed", e); //$NON-NLS-1$
+                LOG.error("Failed to update data model condition operator.", e); //$NON-NLS-1$
             }
         }
 

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdator.java
@@ -1,0 +1,83 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.mdm.repository.ui.wizards.imports;
+
+import org.apache.log4j.Logger;
+import org.talend.core.model.properties.Item;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.amalto.workbench.utils.Util;
+
+
+/**
+ * created by liusongbo on Apr 14, 2016
+ *
+ */
+public class DataModelOperatorUpdator extends AbstractDataModelUpdator implements IOperatorUpdator {
+
+    private static Logger log = Logger.getLogger(DataModelOperatorUpdator.class);
+
+    @Override
+    public boolean updateConditionOperator(Item item) {
+        return updateDatamodel(item);
+    }
+
+    @Override
+    protected String doUpdation(byte[] byteContent) {
+        return updateOperator(byteContent);
+    }
+
+    @Override
+    protected boolean accept(Item item) {
+        String path = item.getState().getPath();
+        return !path.toLowerCase().startsWith("system"); //$NON-NLS-1$
+    }
+
+    private String updateOperator(byte[] byteContent) {
+        String result = null;
+        if (byteContent != null) {
+
+            boolean modified = false;
+            try {
+                Document document = getSchemaDocument(byteContent);
+                NodeList appinfoTags = document.getElementsByTagName("xsd:appinfo"); //$NON-NLS-1$
+                int len = appinfoTags.getLength();
+                for (int i = 0; i < len; i++) {
+                    Node appItem = appinfoTags.item(i);
+                    Node sourceAttr = appItem.getAttributes().getNamedItem("source"); //$NON-NLS-1$
+                    if (sourceAttr.getNodeValue().equals("X_ForeignKey_Filter")) { //$NON-NLS-1$
+                        String content = appItem.getTextContent();
+                        if (content.contains("Strict Contains") || content.contains("Contains Text Of")) { //$NON-NLS-1$//$NON-NLS-2$
+                            content = content.replaceAll("Contains Text Of", "Contains"); //$NON-NLS-1$ //$NON-NLS-2$
+                            content = content.replaceAll("Strict Contains", "Contains"); //$NON-NLS-1$ //$NON-NLS-2$
+                            appItem.setTextContent(content);
+
+                            modified = true;
+                        }
+                    }
+                }
+
+                if (modified) {
+                    result = Util.nodeToString(document);
+                }
+
+            } catch (Exception e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+
+        return result;
+    }
+}

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelSchemaUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelSchemaUpdator.java
@@ -65,7 +65,7 @@ public class DataModelSchemaUpdator extends AbstractDataModelUpdator {
                 }
 
             } catch (Exception e) {
-                LOG.error("Update data model schema failed", e); //$NON-NLS-1$
+                LOG.error("Failed to update data model schema.", e); //$NON-NLS-1$
             }
         }
 

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelSchemaUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelSchemaUpdator.java
@@ -1,0 +1,138 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.mdm.repository.ui.wizards.imports;
+
+import org.apache.log4j.Logger;
+import org.talend.core.model.properties.Item;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.amalto.workbench.utils.Util;
+
+/**
+ * @author sbliu
+ *
+ */
+public class DataModelSchemaUpdator extends AbstractDataModelUpdator {
+
+    private static Logger LOG = Logger.getLogger(DataModelSchemaUpdator.class);
+
+    private static final String TAG_XSD_ELEMENT = "xsd:element"; //$NON-NLS-1$
+
+    private static final String TAG_XSD_COMPLEXTYPE = "xsd:complexType"; //$NON-NLS-1$
+
+    private static final String TAG_XSD_SEQUENCE = "xsd:sequence"; //$NON-NLS-1$
+
+    private static final String ATTR_NAME = "name"; //$NON-NLS-1$
+
+    private static final String UUID = "UUID"; //$NON-NLS-1$
+
+    private static final String TIME_IN_MILLIS = "TimeInMillis"; //$NON-NLS-1$
+
+    public boolean updateSchema(Item item) {
+        return updateDatamodel(item);
+    }
+
+    @Override
+    protected boolean accept(Item datamodelItem) {
+        return "UpdateReport".equalsIgnoreCase(datamodelItem.getProperty().getLabel()); //$NON-NLS-1$
+    }
+
+    @Override
+    protected String doUpdation(byte[] byteContent) {
+        return updateSchema(byteContent);
+    }
+
+    private String updateSchema(byte[] byteContent) {
+        String result = null;
+        if (byteContent != null) {
+            boolean modified = false;
+            try {
+                Document document = getSchemaDocument(byteContent);
+
+                modified = handleUUIDElement(document);
+
+                if (modified) {
+                    result = Util.formatXsdSource(Util.nodeToString(document));
+                }
+
+            } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean handleUUIDElement(Document document) {
+        boolean modified = false;
+
+        NodeList complexTypeNodeList = document.getElementsByTagName(TAG_XSD_COMPLEXTYPE);
+        if (complexTypeNodeList.getLength() > 0) {
+            Node complexTypeNode = complexTypeNodeList.item(0);
+            if (complexTypeNode.hasChildNodes()) {
+                Node sequenceNode = complexTypeNode.getFirstChild();
+                while (sequenceNode != null && !sequenceNode.getNodeName().equals(TAG_XSD_SEQUENCE)) {
+                    sequenceNode = sequenceNode.getNextSibling();
+                }
+
+                if (sequenceNode != null) {
+                    Node time_in_millis_Element = null;
+                    boolean hasUUIDElement = false;
+                    
+                    Node child = sequenceNode.getFirstChild();
+                    while (child != null) {
+                        if (child.getAttributes() != null) {
+                            Node namedItem = child.getAttributes().getNamedItem(ATTR_NAME);
+                            if (namedItem != null) {
+                                if (UUID.equals(namedItem.getNodeValue())) {
+                                    hasUUIDElement = true;
+                                    break;
+                                } else if (TIME_IN_MILLIS.equals(namedItem.getNodeValue())) {
+                                    time_in_millis_Element = child;
+                                }
+                            }
+                        }
+                        child = child.getNextSibling();
+                    }
+                    
+                    if (!hasUUIDElement) {
+                        Element element = createElement(document, UUID);
+                        modified = true;
+                        if (time_in_millis_Element != null) {
+                            sequenceNode.insertBefore(element, time_in_millis_Element.getNextSibling());
+                        } else {
+                            sequenceNode.appendChild(element);
+                        }
+                    }
+                }
+            }
+        }
+
+        return modified;
+    }
+
+    private Element createElement(Document document, String nameValue) {
+        Element idElement = document.createElement(TAG_XSD_ELEMENT);
+        idElement.setAttribute("maxOccurs", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        idElement.setAttribute("minOccurs", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+        idElement.setAttribute("name", nameValue); //$NON-NLS-1$
+        idElement.setAttribute("nillable", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+        idElement.setAttribute("type", "xsd:string"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        return idElement;
+    }
+
+}

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelSchemaUpdator.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelSchemaUpdator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -21,13 +21,9 @@ import org.w3c.dom.NodeList;
 
 import com.amalto.workbench.utils.Util;
 
-/**
- * @author sbliu
- *
- */
 public class DataModelSchemaUpdator extends AbstractDataModelUpdator {
 
-    private static Logger LOG = Logger.getLogger(DataModelSchemaUpdator.class);
+    private static final Logger LOG = Logger.getLogger(DataModelSchemaUpdator.class);
 
     private static final String TAG_XSD_ELEMENT = "xsd:element"; //$NON-NLS-1$
 
@@ -51,7 +47,7 @@ public class DataModelSchemaUpdator extends AbstractDataModelUpdator {
     }
 
     @Override
-    protected String doUpdation(byte[] byteContent) {
+    protected String doUpdate(byte[] byteContent) {
         return updateSchema(byteContent);
     }
 
@@ -69,7 +65,7 @@ public class DataModelSchemaUpdator extends AbstractDataModelUpdator {
                 }
 
             } catch (Exception e) {
-                LOG.error(e.getMessage(), e);
+                LOG.error("Update data model schema failed", e); //$NON-NLS-1$
             }
         }
 

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/UpdatorProvider.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/UpdatorProvider.java
@@ -24,24 +24,24 @@ import org.talend.mdm.repository.model.mdmproperties.impl.WSViewItemImpl;
  * created by liusongbo on Apr 18, 2016
  *
  */
-public class OperatorUpdatorProvider {
+public class UpdatorProvider {
 
     private Map<Class, IOperatorUpdator> updators;
 
-    private static OperatorUpdatorProvider instance = new OperatorUpdatorProvider();
+    private static UpdatorProvider instance = new UpdatorProvider();
 
-    public static OperatorUpdatorProvider instance() {
+    public static UpdatorProvider instance() {
         return instance;
     }
 
     public void updateOperator(Item item) {
-        IOperatorUpdator updator = getUpdator(item.getClass());
+        IOperatorUpdator updator = getOperatorUpdator(item.getClass());
         if (updator != null) {
             updator.updateConditionOperator(item);
         }
     }
 
-    private IOperatorUpdator getUpdator(Class clazz) {
+    private IOperatorUpdator getOperatorUpdator(Class clazz) {
         if (updators == null) {
             updators = new HashMap<Class, IOperatorUpdator>();
         }
@@ -53,7 +53,7 @@ public class OperatorUpdatorProvider {
             }
 
             if (clazz == WSDataModelItemImpl.class) {
-                updator = new DatamodelOperatorUpdator();
+                updator = new DataModelOperatorUpdator();
             }
 
             if (updator != null) {
@@ -70,6 +70,10 @@ public class OperatorUpdatorProvider {
         }
 
         updators.put(clazz, updator);
+    }
+
+    public void updateDataModelSchema(Item item) {
+        new DataModelSchemaUpdator().updateSchema(item);
     }
 
 }

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/UpdatorProvider.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/UpdatorProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -20,10 +20,6 @@ import org.talend.mdm.repository.model.mdmproperties.impl.WSDataModelItemImpl;
 import org.talend.mdm.repository.model.mdmproperties.impl.WSViewItemImpl;
 
 
-/**
- * created by liusongbo on Apr 18, 2016
- *
- */
 public class UpdatorProvider {
 
     private Map<Class, IOperatorUpdator> updators;

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/DataModelImportHandler.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/DataModelImportHandler.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/DataModelImportHandler.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/DataModelImportHandler.java
@@ -17,7 +17,7 @@ import org.talend.commons.exception.PersistenceException;
 import org.talend.core.model.properties.Item;
 import org.talend.core.model.repository.IRepositoryViewObject;
 import org.talend.mdm.repository.model.mdmproperties.WSDataModelItem;
-import org.talend.mdm.repository.ui.wizards.imports.OperatorUpdatorProvider;
+import org.talend.mdm.repository.ui.wizards.imports.UpdatorProvider;
 import org.talend.repository.items.importexport.handlers.model.ImportItem;
 import org.talend.repository.items.importexport.manager.ResourcesManager;
 
@@ -46,7 +46,8 @@ public class DataModelImportHandler extends CommonMdmImportHandler {
 
     @Override
     protected void update(IRepositoryViewObject object, ImportItem selectedImportItem) throws PersistenceException {
-        OperatorUpdatorProvider.instance().updateOperator(object.getProperty().getItem());
+        UpdatorProvider.instance().updateOperator(object.getProperty().getItem());
+        UpdatorProvider.instance().updateDataModelSchema(object.getProperty().getItem());
 
         super.update(object, selectedImportItem);
     }

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/ViewProcessImportHandler.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/ViewProcessImportHandler.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/ViewProcessImportHandler.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/ui/wizards/imports/handlers/ViewProcessImportHandler.java
@@ -18,7 +18,7 @@ import org.talend.mdm.repository.core.impl.transformerV2.ITransformerV2NodeConsD
 import org.talend.mdm.repository.core.impl.view.IViewNodeConstDef;
 import org.talend.mdm.repository.model.mdmproperties.WSTransformerV2Item;
 import org.talend.mdm.repository.model.mdmproperties.WSViewItem;
-import org.talend.mdm.repository.ui.wizards.imports.OperatorUpdatorProvider;
+import org.talend.mdm.repository.ui.wizards.imports.UpdatorProvider;
 import org.talend.mdm.repository.utils.RepositoryTransformUtil;
 import org.talend.repository.items.importexport.handlers.model.ImportItem;
 
@@ -43,7 +43,7 @@ public class ViewProcessImportHandler extends CommonMdmImportHandler {
                     item.getState().setPath(IPath.SEPARATOR + IViewNodeConstDef.PATH_SEARCHFILTER + statePath);
                 }
             }
-            OperatorUpdatorProvider.instance().updateOperator(item);
+            UpdatorProvider.instance().updateOperator(item);
         }
 
         if (item instanceof WSTransformerV2Item) {

--- a/test/plugins/org.talend.mdm.repository.test/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdatorTest.java
+++ b/test/plugins/org.talend.mdm.repository.test/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdatorTest.java
@@ -1,3 +1,15 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
 package org.talend.mdm.repository.ui.wizards.imports;
 
 import static org.junit.Assert.*;
@@ -30,7 +42,7 @@ import com.amalto.workbench.exadapter.ExAdapterManager;
 @PowerMockIgnore({ "org.eclipse.core.runtime.*" })
 public class DataModelOperatorUpdatorTest {
 
-    private static Logger log = Logger.getLogger(DataModelOperatorUpdatorTest.class);
+    private static final Logger LOG = Logger.getLogger(DataModelOperatorUpdatorTest.class);
 
     @Test
     public void testUpdateConditionOperator() {
@@ -64,7 +76,7 @@ public class DataModelOperatorUpdatorTest {
             assertFalse(xsdSchema.contains("Contains Text Of")); //$NON-NLS-1$
             assertTrue(xsdSchema.contains("Contains")); //$NON-NLS-1$
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOG.error(e.getMessage(), e);
         }
     }
 

--- a/test/plugins/org.talend.mdm.repository.test/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdatorTest.java
+++ b/test/plugins/org.talend.mdm.repository.test/src/main/java/org/talend/mdm/repository/ui/wizards/imports/DataModelOperatorUpdatorTest.java
@@ -28,9 +28,9 @@ import com.amalto.workbench.exadapter.ExAdapterManager;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ RepositoryResourceUtil.class, ExAdapterManager.class })
 @PowerMockIgnore({ "org.eclipse.core.runtime.*" })
-public class DatamodelOperatorUpdatorTest {
+public class DataModelOperatorUpdatorTest {
 
-    private static Logger log = Logger.getLogger(DatamodelOperatorUpdatorTest.class);
+    private static Logger log = Logger.getLogger(DataModelOperatorUpdatorTest.class);
 
     @Test
     public void testUpdateConditionOperator() {
@@ -56,7 +56,7 @@ public class DatamodelOperatorUpdatorTest {
 
             PowerMockito.mockStatic(RepositoryResourceUtil.class);
 
-            boolean updated = new DatamodelOperatorUpdator().updateConditionOperator(wsdataModelItem);
+            boolean updated = new DataModelOperatorUpdator().updateConditionOperator(wsdataModelItem);
             String xsdSchema = wsdataModelItem.getWsDataModel().getXsdSchema();
             assertTrue(updated);
             assertNotNull(xsdSchema);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11900

**What is the current behavior?** (You should also link to an open issue here)
 With very high workload for Cluster mode, mdm Update Report may face error like Cannot insert duplicate key in object 'dbo.X_UPDATE_REPORT'. 

**What is the new behavior?**
For Cluster mode problem, it needs change the update report schema, this led to Update Report change in standalone mode on studio side also. For Standalone mode, UpdateReport tables PK=Time + Source, add a new field UUID in UpdateReport .


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
