### PR TITLE
TMDM-13127 Error message will be shown when importing content to server failed.

### DIFF
--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ImportDataContentProcess.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ImportDataContentProcess.java
@@ -240,7 +240,7 @@ public class ImportDataContentProcess extends AbstractDataContentProcess {
                 unmarshaller.setWhitespacePreserve(true);
                 unmarshaller.setMapping(mapping);
             } catch (Exception e) {
-                LOG.error("Prepare unmarshaller error", e);
+                LOG.error("Failed to prepare unmarshaller.", e);
 
                 IStatus errStatus = new Status(IStatus.ERROR, RepositoryPlugin.PLUGIN_ID,
                         Messages.ImportDataClusterAction_errorTitle, e);

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ImportDataContentProcess.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ImportDataContentProcess.java
@@ -66,7 +66,7 @@ import com.amalto.workbench.webservices.WSItem;
  */
 public class ImportDataContentProcess extends AbstractDataContentProcess {
 
-    private static Logger log = Logger.getLogger(ImportDataContentProcess.class);
+    private static final Logger LOG = Logger.getLogger(ImportDataContentProcess.class);
 
     private MultiStatus processResult;
 
@@ -240,7 +240,7 @@ public class ImportDataContentProcess extends AbstractDataContentProcess {
                 unmarshaller.setWhitespacePreserve(true);
                 unmarshaller.setMapping(mapping);
             } catch (Exception e) {
-                log.error(e.getLocalizedMessage(), e);
+                LOG.error("Prepare unmarshaller error", e);
 
                 IStatus errStatus = new Status(IStatus.ERROR, RepositoryPlugin.PLUGIN_ID,
                         Messages.ImportDataClusterAction_errorTitle, e);
@@ -266,9 +266,9 @@ public class ImportDataContentProcess extends AbstractDataContentProcess {
                     String content = wsItem.getContent();
                     list.add(content);
                 } catch (Exception e) {
-                    log.error(e.getLocalizedMessage(), e);
                     String msg = Messages.bind(Messages.ImportDataClusterAction_importErrorMsg, concept, dName,
                             e.getLocalizedMessage());
+                    LOG.error(msg, e);
                     IStatus errStatus = new Status(IStatus.ERROR, RepositoryPlugin.PLUGIN_ID, msg, e);
                     getResult().add(errStatus);
                     return;
@@ -313,10 +313,12 @@ public class ImportDataContentProcess extends AbstractDataContentProcess {
                         }
                         manager.notify();
                     }
+                    
+                    checkFailureReport(manager);
                 } catch (Exception e) {
-                    log.error(e.getLocalizedMessage(), e);
                     String msg = Messages.bind(Messages.ImportDataClusterAction_importErrorMsg, concept, dName,
                             e.getLocalizedMessage());
+                    LOG.error(msg, e);
                     IStatus errStatus = new Status(IStatus.ERROR, RepositoryPlugin.PLUGIN_ID, msg, e);
                     getResult().add(errStatus);
                 }
@@ -326,9 +328,19 @@ public class ImportDataContentProcess extends AbstractDataContentProcess {
             return;
         }
 
+        private void checkFailureReport(InputStreamMerger manager) throws Exception {
+            Throwable lastReportedFailure = manager.getLastReportedFailure();
+            if(lastReportedFailure != null) {
+                if(!(lastReportedFailure instanceof Exception)) {
+                    throw new RuntimeException(lastReportedFailure);
+                } else {
+                    throw (Exception)lastReportedFailure;
+                }
+            }
+        }
+
         public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
             importClusterContents(monitor);
-
         }
     }
 

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ImportDataContentProcess.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/datacontent/impl/ImportDataContentProcess.java
@@ -330,11 +330,11 @@ public class ImportDataContentProcess extends AbstractDataContentProcess {
 
         private void checkFailureReport(InputStreamMerger manager) throws Exception {
             Throwable lastReportedFailure = manager.getLastReportedFailure();
-            if(lastReportedFailure != null) {
-                if(!(lastReportedFailure instanceof Exception)) {
+            if (lastReportedFailure != null) {
+                if (!(lastReportedFailure instanceof Exception)) {
                     throw new RuntimeException(lastReportedFailure);
                 } else {
-                    throw (Exception)lastReportedFailure;
+                    throw (Exception) lastReportedFailure;
                 }
             }
         }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13127

**What is the current behavior?** (You should also link to an open issue here)
1. Import data to server from Studio always alert message of successfully(before eclipse platform upgrade to 4.10).
2. Import content to server & export content from server does not work after eclipse platform upgraded to 4.10 .

**What is the new behavior?**
1. Import content to server & export content from server work after eclipse platform upgraded to 4.10 .
2. Import data to server from Studio failed will show give error message to user and log it.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
