### PR TITLE
TMDM-13199  [Eclipse 4.10] Throwing NPE when switch to ER editor after upgrading to Eclipse 4.10

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.mdm.workbench/META-INF/MANIFEST.MF
@@ -41,7 +41,9 @@ Require-Bundle: org.eclipse.ui,
  org.talend.libraries.ui,
  org.talend.mdm.ws;resolution:=optional,
  org.talend.mdm.ws.enterprise;resolution:=optional;visibility:=reexport,
- org.talend.mdm.commmon
+ org.talend.mdm.commmon,
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.ui.workbench
 Eclipse-AutoStart: true
 Eclipse-RegisterBuddy: org.talend.testutils
 Bundle-ClassPath: .,


### PR DESCRIPTION

**What is the current behavior?** (You should also link to an open issue here)
If the datamodel is changed, when switching between ER and datamodel editor, it always pops a save dialog.
link: https://jira.talendforge.org/browse/TMDM-13199


**What is the new behavior?**
No more save dialog pops in this case.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
