### PR TITLE
TMDM-13982 Synchronize "Category" annotation after rename a “field” of entity

### DIFF
--- a/main/plugins/org.talend.designer.components.tomprovider/src/org/talend/designer/components/tomprovider/TomLocalComponentsProvider.java
+++ b/main/plugins/org.talend.designer.components.tomprovider/src/org/talend/designer/components/tomprovider/TomLocalComponentsProvider.java
@@ -5,6 +5,7 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
+import org.talend.commons.exception.ExceptionHandler;
 import org.talend.core.model.components.AbstractComponentsProvider;
 
 
@@ -18,7 +19,7 @@ public class TomLocalComponentsProvider extends AbstractComponentsProvider {
             fileUrl = FileLocator.toFileURL(url);
             return new File(fileUrl.getPath());
         } catch (Exception e) {
-            // ExceptionHandler.process(e);
+            ExceptionHandler.process(e);
         }
         return null;
     }

--- a/main/plugins/org.talend.designer.components.tomprovider/src/org/talend/designer/components/tomprovider/TomLocalComponentsProvider.java
+++ b/main/plugins/org.talend.designer.components.tomprovider/src/org/talend/designer/components/tomprovider/TomLocalComponentsProvider.java
@@ -5,7 +5,6 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
-import org.talend.commons.exception.ExceptionHandler;
 import org.talend.core.model.components.AbstractComponentsProvider;
 
 
@@ -19,7 +18,7 @@ public class TomLocalComponentsProvider extends AbstractComponentsProvider {
             fileUrl = FileLocator.toFileURL(url);
             return new File(fileUrl.getPath());
         } catch (Exception e) {
-            ExceptionHandler.process(e);
+            // ExceptionHandler.process(e);
         }
         return null;
     }

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDDeleteParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDDeleteParticleAction.java
@@ -14,7 +14,6 @@ package com.amalto.workbench.actions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,7 +24,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.xsd.XSDComplexTypeDefinition;
 import org.eclipse.xsd.XSDElementDeclaration;
 import org.eclipse.xsd.XSDIdentityConstraintDefinition;
 import org.eclipse.xsd.XSDModelGroup;
@@ -37,7 +35,6 @@ import com.amalto.workbench.editors.DataModelMainPage;
 import com.amalto.workbench.i18n.Messages;
 import com.amalto.workbench.image.EImage;
 import com.amalto.workbench.image.ImageCache;
-import com.amalto.workbench.utils.XSDAnnotationsStructure;
 import com.amalto.workbench.utils.XSDUtil;
 import com.amalto.workbench.utils.XtentisException;
 
@@ -89,10 +86,11 @@ public class XSDDeleteParticleAction extends UndoAction {
                         particle.getContainer().getClass().getName()));
             }
 
-            List<XSDElementDeclaration> concepts = getConceptsOfField(particle);
+            List<XSDElementDeclaration> concepts = XSDUtil.getConceptsOfField(particle);
             for (XSDElementDeclaration concept : concepts) {
                 removePK(concept, decl);
-                syncEntityAnnotation(concept, particle, decl.getName());
+                XSDUtil.syncEntityCategoryAnnotation(concept, particle, decl.getName(), null);
+                concept.updateElement();
             }
 
             XSDModelGroup group = (XSDModelGroup) particle.getContainer();
@@ -110,20 +108,6 @@ public class XSDDeleteParticleAction extends UndoAction {
             return Status.CANCEL_STATUS;
         }
         return Status.OK_STATUS;
-    }
-
-    private List<XSDElementDeclaration> getConceptsOfField(XSDParticle field) {
-        List<XSDElementDeclaration> conceptsOfField = new ArrayList<>();
-
-        XSDComplexTypeDefinition typedef = XSDUtil.getContainerTypeOfField(field);
-        List<XSDElementDeclaration> concepts = schema.getElementDeclarations();
-        for (XSDElementDeclaration concept : concepts) {
-            if (XSDUtil.hasBoundToConcept(typedef, concept)) {
-                conceptsOfField.add(concept);
-            }
-        }
-
-        return conceptsOfField;
     }
 
     private void removePK(XSDElementDeclaration concept, XSDElementDeclaration field) {
@@ -151,14 +135,6 @@ public class XSDDeleteParticleAction extends UndoAction {
                 concept.getIdentityConstraintDefinitions().remove(identify);
             }
         }
-    }
-
-    private void syncEntityAnnotation(XSDElementDeclaration conceptOfPariticle, XSDParticle particle, String fieldName) {
-        XSDAnnotationsStructure annoStructure = new XSDAnnotationsStructure(conceptOfPariticle);
-        Map<String, String> fieldCategoryMap = annoStructure.getFieldCategoryMap();
-        fieldCategoryMap.remove(fieldName);
-        annoStructure.setCategoryFields(fieldCategoryMap);
-        conceptOfPariticle.updateElement();
     }
 
     public void runWithEvent(Event event) {

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDDeleteParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDDeleteParticleAction.java
@@ -89,7 +89,7 @@ public class XSDDeleteParticleAction extends UndoAction {
             List<XSDElementDeclaration> concepts = XSDUtil.getConceptsOfField(particle);
             for (XSDElementDeclaration concept : concepts) {
                 removePK(concept, decl);
-                XSDUtil.syncEntityCategoryAnnotation(concept, particle, decl.getName(), null);
+                XSDUtil.syncEntityCategoryAnnotation(concept, decl.getName(), null);
                 concept.updateElement();
             }
 

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
@@ -50,6 +50,7 @@ import com.amalto.workbench.image.ImageCache;
 import com.amalto.workbench.providers.datamodel.SchemaTreeContentProvider;
 import com.amalto.workbench.utils.IConstants;
 import com.amalto.workbench.utils.Util;
+import com.amalto.workbench.utils.XSDUtil;
 
 public class XSDEditParticleAction extends UndoAction implements SelectionListener {
 
@@ -176,15 +177,34 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
                 if (elem.getAttributes().getNamedItem("type") != null) {
                     elem.getAttributes().removeNamedItem("type");//$NON-NLS-1$
                 }
+
+                if (ref == null) {
+                    // TODO remove from entity category annotation if exist
+                    List<XSDElementDeclaration> conceptsOfField = XSDUtil.getConceptsOfField(selParticle);
+                    for (XSDElementDeclaration concept : conceptsOfField) {
+                        XSDUtil.syncEntityCategoryAnnotation(concept, selParticle, decl.getName(), null);
+                        concept.updateElement();
+                    }
+                }
                 decl.updateElement();
-            } else if (ref != null) {
-                XSDSimpleTypeDefinition stringType = ((SchemaTreeContentProvider) page.getTreeViewer().getContentProvider())
-                        .getXsdSchema().getSchemaForSchema()
-                        .resolveSimpleTypeDefinition(XSDConstants.SCHEMA_FOR_SCHEMA_URI_2001, "string"); //$NON-NLS-1$
-                decl.setResolvedElementDeclaration(decl);
-                selParticle.setTerm(decl);
-                decl.setTypeDefinition(stringType);
-                decl.updateElement();
+            } else {
+                if (ref != null) {
+                    XSDSimpleTypeDefinition stringType = ((SchemaTreeContentProvider) page.getTreeViewer().getContentProvider())
+                            .getXsdSchema().getSchemaForSchema()
+                            .resolveSimpleTypeDefinition(XSDConstants.SCHEMA_FOR_SCHEMA_URI_2001, "string"); //$NON-NLS-1$
+                    decl.setResolvedElementDeclaration(decl);
+                    selParticle.setTerm(decl);
+                    decl.setTypeDefinition(stringType);
+                    decl.updateElement();
+                } else {
+                    // TODO handle entity category annotation change if exist
+                    List<XSDElementDeclaration> conceptsOfField = XSDUtil.getConceptsOfField(selParticle);
+                    for (XSDElementDeclaration concept : conceptsOfField) {
+                        XSDUtil.syncEntityCategoryAnnotation(concept, selParticle, initEleName, elementName);
+                        concept.updateElement();
+                    }
+                }
+
                 selParticle.updateElement();
             }
 

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
@@ -178,8 +178,7 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
                     elem.getAttributes().removeNamedItem("type");//$NON-NLS-1$
                 }
 
-                if (ref == null) {
-                    // TODO remove from entity category annotation if exist
+                if (ref == null) {// remove from entity category annotation if exist
                     List<XSDElementDeclaration> conceptsOfField = XSDUtil.getConceptsOfField(selParticle);
                     for (XSDElementDeclaration concept : conceptsOfField) {
                         XSDUtil.syncEntityCategoryAnnotation(concept, decl.getName(), null);
@@ -196,8 +195,7 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
                     selParticle.setTerm(decl);
                     decl.setTypeDefinition(stringType);
                     decl.updateElement();
-                } else {
-                    // TODO handle entity category annotation change if exist
+                } else {// handle entity category annotation change if exist
                     List<XSDElementDeclaration> conceptsOfField = XSDUtil.getConceptsOfField(selParticle);
                     for (XSDElementDeclaration concept : conceptsOfField) {
                         XSDUtil.syncEntityCategoryAnnotation(concept, initEleName, elementName);

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/actions/XSDEditParticleAction.java
@@ -182,7 +182,7 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
                     // TODO remove from entity category annotation if exist
                     List<XSDElementDeclaration> conceptsOfField = XSDUtil.getConceptsOfField(selParticle);
                     for (XSDElementDeclaration concept : conceptsOfField) {
-                        XSDUtil.syncEntityCategoryAnnotation(concept, selParticle, decl.getName(), null);
+                        XSDUtil.syncEntityCategoryAnnotation(concept, decl.getName(), null);
                         concept.updateElement();
                     }
                 }
@@ -200,7 +200,7 @@ public class XSDEditParticleAction extends UndoAction implements SelectionListen
                     // TODO handle entity category annotation change if exist
                     List<XSDElementDeclaration> conceptsOfField = XSDUtil.getConceptsOfField(selParticle);
                     for (XSDElementDeclaration concept : conceptsOfField) {
-                        XSDUtil.syncEntityCategoryAnnotation(concept, selParticle, initEleName, elementName);
+                        XSDUtil.syncEntityCategoryAnnotation(concept, initEleName, elementName);
                         concept.updateElement();
                     }
                 }

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XSDUtil.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XSDUtil.java
@@ -19,10 +19,12 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xsd.XSDAnnotation;
 import org.eclipse.xsd.XSDComplexTypeContent;
@@ -406,6 +408,41 @@ public class XSDUtil {
         }
 
         return false;
+    }
+
+    /*
+     * search the entities that own the 'field' as 1-level children
+     */
+    public static List<XSDElementDeclaration> getConceptsOfField(XSDParticle field) {
+        List<XSDElementDeclaration> conceptsOfField = new ArrayList<>();
+
+        XSDSchema schema = field.getSchema();
+        XSDComplexTypeDefinition typedef = XSDUtil.getContainerTypeOfField(field);
+        List<XSDElementDeclaration> concepts = schema.getElementDeclarations();
+        for (XSDElementDeclaration concept : concepts) {
+            if (XSDUtil.hasBoundToConcept(typedef, concept)) {
+                conceptsOfField.add(concept);
+            }
+        }
+
+        return conceptsOfField;
+    }
+
+    public static void syncEntityCategoryAnnotation(XSDElementDeclaration conceptOfPariticle, XSDParticle particle,
+            String oldFieldName, String newFieldName) {
+        Objects.requireNonNull(oldFieldName);
+
+        XSDAnnotationsStructure annoStructure = new XSDAnnotationsStructure(conceptOfPariticle);
+        Map<String, String> fieldCategoryMap = annoStructure.getFieldCategoryMap();
+        if (StringUtils.isBlank(newFieldName)) {
+            fieldCategoryMap.remove(oldFieldName);
+            annoStructure.setCategoryFields(fieldCategoryMap);
+        } else if (!oldFieldName.equals(newFieldName)) {
+            String category = fieldCategoryMap.get(oldFieldName);
+            fieldCategoryMap.remove(oldFieldName);
+            fieldCategoryMap.put(newFieldName, category);
+            annoStructure.setCategoryFields(fieldCategoryMap);
+        }
     }
 
     public static boolean isValidatedXSDDate(String newText) {

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XSDUtil.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XSDUtil.java
@@ -428,8 +428,8 @@ public class XSDUtil {
         return conceptsOfField;
     }
 
-    public static void syncEntityCategoryAnnotation(XSDElementDeclaration conceptOfPariticle, XSDParticle particle,
-            String oldFieldName, String newFieldName) {
+    public static void syncEntityCategoryAnnotation(XSDElementDeclaration conceptOfPariticle, String oldFieldName,
+            String newFieldName) {
         Objects.requireNonNull(oldFieldName);
 
         XSDAnnotationsStructure annoStructure = new XSDAnnotationsStructure(conceptOfPariticle);


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-13982


**What is the new behavior?**
when field was renamed, sync the category annotation of entity.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
