### PR TITLE
TMDM-14104  [Studio] Filter by category improvement

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XSDUtil.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XSDUtil.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -345,7 +344,6 @@ public class XSDUtil {
     public static List<String> getFields(XSDElementDeclaration concept) {
         XSDComplexTypeDefinition complexType = (XSDComplexTypeDefinition) concept.getType();
         List<String> fields = getFields(complexType);
-        fields = fields.stream().sorted().collect(Collectors.toList());
         return fields;
     }
 
@@ -356,7 +354,7 @@ public class XSDUtil {
             XSDParticleContent content = elementParticle.getContent();
             if (content instanceof XSDElementDeclaration) {
                 XSDElementDeclaration field = (XSDElementDeclaration) content;
-                if (field.getName() != null) {
+                if (field.getName() != null && field.getType() != null) {
                     fields.add(field.getName());
                 }
             }

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/utils/CategoryTest.java
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/utils/CategoryTest.java
@@ -183,9 +183,20 @@ public class CategoryTest {
 
         List<String> fields = XSDUtil.getFields(decl);
         assertTrue(fields.size() == 3);
-        assertTrue(fields.get(0).equals("id"));
-        assertTrue(fields.get(1).equals("name"));
-        assertTrue(fields.get(2).equals("size"));
+        assertTrue(fields.get(0).equals("size"));
+        assertTrue(fields.get(1).equals("id"));
+        assertTrue(fields.get(2).equals("name"));
+    }
+
+    @Test
+    public void testGetFieldsWithReference() {
+        XSDSchema schema = getSchema("TestCategory05.xsd");
+        XSDElementDeclaration decl = schema.getElementDeclarations().get(1);
+
+        // the return list shouldn't include the field with reference type.
+        List<String> fields = XSDUtil.getFields(decl);
+        assertTrue(fields.size() == 1);
+        assertTrue(fields.get(0).equals("EntityBId"));
     }
 
     @Test

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/utils/TestCategory05.xsd
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/utils/TestCategory05.xsd
@@ -1,0 +1,25 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="EntityA">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element name="EntityAId" type="xsd:string" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="EntityA">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="EntityAId" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="EntityB">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element name="EntityBId" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" ref="EntityA" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="EntityB">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="EntityBId" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
 XSDUtil return fields by alphabetical order and include "reference" field.

**What is the new behavior?**
1. Show fields by default order the same with defined in entity instead of alphabetical order.
2. Fixed when calling XSDUtil.getFields(), the returned fields include 'reference' field.
3. Add and update JUnit for the above fix.
link:  https://jira.talendforge.org/browse/TMDM-14104


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
