### PR TITLE
TMDM-14523 Password is in clear

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
@@ -18,8 +18,6 @@ public class ExtensibleEditorContent {
 
     private static final String TAG_PASSWORD_END = "</password>";
 
-    private static final String TAG_PASSWORD_EMPTY = "<password/>";
-
     private static final String MASKCODE_CHAR = "*";
 
     private static final String MASKCODE = "*******";
@@ -55,8 +53,7 @@ public class ExtensibleEditorContent {
                         this.content = splitNewContent[0] + splitContent[1] + splitNewContent[2];
                     } else {
                         // origin content does not contains password part, this handle copy/input contents which
-                        // contains
-                        // password part, result: leave password empty
+                        // contains password part, result: leave password empty
                         this.content = splitNewContent[0] + (TAG_PASSWORD_BEGIN + TAG_PASSWORD_END) + splitNewContent[2];
                     }
 
@@ -103,18 +100,12 @@ public class ExtensibleEditorContent {
         return true;
     }
 
-    // empty tag has low priority
+    // No need consider empty tag
     private String[] splitByPasswordTag(String _content) {
         int start = _content.indexOf(TAG_PASSWORD_BEGIN);
         int end = _content.lastIndexOf(TAG_PASSWORD_END) + TAG_PASSWORD_END.length();
-        int firstEmptyTagIndex = _content.indexOf(TAG_PASSWORD_EMPTY);
         if (start != -1) {
             return new String[] { _content.substring(0, start), _content.substring(start, end), _content.substring(end) };
-        } else if (firstEmptyTagIndex != -1) {
-            int lastEmptyTagIndex = _content.lastIndexOf(TAG_PASSWORD_EMPTY);
-            return new String[] { _content.substring(0, firstEmptyTagIndex),
-                    _content.substring(firstEmptyTagIndex, lastEmptyTagIndex + TAG_PASSWORD_EMPTY.length()),
-                    _content.substring(lastEmptyTagIndex + TAG_PASSWORD_EMPTY.length()) };
         }
 
         return null;

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
@@ -14,7 +14,17 @@ package com.amalto.workbench.widgets.xmleditor;
 
 public class ExtensibleEditorContent {
 
+    private static final String TAG_PASSWORD_GEGIN = "<password>";
+
+    private static final String TAG_PASSWORD_END = "</password>";
+
+    private static final String MASKCODE_CHAR = "*";
+
+    private static final String MASKCODE = "*******";
+
     protected String content = "";//$NON-NLS-1$
+
+    protected String maskedContent = "";//$NON-NLS-1$
 
     public ExtensibleEditorContent(String content) {
 
@@ -26,11 +36,66 @@ public class ExtensibleEditorContent {
         return content;
     }
 
-    public void setContent(String content) {
+    public String getMaskContent() {
+        return maskedContent;
+    }
 
-        if (content == null)
+    public void setContent(String newContent) {
+        if (newContent == null) {
             this.content = "";//$NON-NLS-1$
-        else
-            this.content = content;
+            this.maskedContent = "";
+        } else {
+            if (isPasswordHiden(newContent)) {
+                if (contentChanged(newContent)) {
+                    String[] splitNewContent = splitbyPasswordTag(newContent);
+                    String[] splitContent = splitbyPasswordTag(content);
+                    this.content = splitNewContent[0] + splitContent[1] + splitNewContent[2];
+                    this.maskedContent = hidePassword(content);
+                }
+            } else {
+                this.content = newContent;
+                this.maskedContent = hidePassword(content);
+            }
+        }
+    }
+
+    private String hidePassword(final String content) {
+        String[] splitbyPasswordTag = splitbyPasswordTag(content);
+        if (splitbyPasswordTag != null) {
+            return splitbyPasswordTag[0] + (TAG_PASSWORD_GEGIN + MASKCODE + TAG_PASSWORD_END) + splitbyPasswordTag[2];
+        }
+
+        return content;
+    }
+
+    private boolean isPasswordHiden(final String content) {
+        String[] splitbyPasswordTag = splitbyPasswordTag(content);
+        if (splitbyPasswordTag != null) {
+            return splitbyPasswordTag[1].contains(MASKCODE_CHAR);
+        }
+
+        return false;
+    }
+
+    private boolean contentChanged(final String newcontent) {
+        String[] splitbyPassword_newcontent = splitbyPasswordTag(newcontent);
+        String[] splitbyPassword_maskcontent = splitbyPasswordTag(maskedContent);
+
+        if(splitbyPassword_newcontent != null && splitbyPassword_maskcontent != null) {
+            return !(splitbyPassword_newcontent[0].equals(splitbyPassword_maskcontent[0])
+                    && splitbyPassword_newcontent[2].equals(splitbyPassword_maskcontent[2]));
+        }
+        
+        return true;
+    }
+
+    private String[] splitbyPasswordTag(String _content) {
+        int start = _content.indexOf(TAG_PASSWORD_GEGIN);
+        int end = _content.indexOf(TAG_PASSWORD_END) + TAG_PASSWORD_END.length();
+        if (start != -1) {
+            return new String[] { _content.substring(0, start), _content.substring(start, end), _content.substring(end) };
+        }
+
+        return null;
     }
 }

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
@@ -14,14 +14,6 @@ package com.amalto.workbench.widgets.xmleditor;
 
 public class ExtensibleEditorContent {
 
-    private static final String TAG_PASSWORD_BEGIN = "<password>";
-
-    private static final String TAG_PASSWORD_END = "</password>";
-
-    private static final String MASKCODE_CHAR = "*";
-
-    private static final String MASKCODE = "*******";
-
     private String content;
 
     private String maskedContent;
@@ -45,69 +37,88 @@ public class ExtensibleEditorContent {
             this.content = "";//$NON-NLS-1$
             this.maskedContent = "";
         } else {
-            if (isPasswordHidden(newContent)) {
-                if (contentChanged(newContent)) {
-                    String[] splitNewContent = splitByPasswordTag(newContent);
-                    String[] splitContent = splitByPasswordTag(content);
+            if (PasswordTagUtil.isPasswordHidden(newContent)) {
+                if (PasswordTagUtil.isContentChanged(newContent, maskedContent)) {
+                    String[] splitNewContent = PasswordTagUtil.splitByPasswordTag(newContent);
+                    String[] splitContent = PasswordTagUtil.splitByPasswordTag(content);
                     if (splitContent != null) {
                         this.content = splitNewContent[0] + splitContent[1] + splitNewContent[2];
                     } else {
                         // origin content does not contains password part, this handle copy/input contents which
                         // contains password part, result: leave password empty
-                        this.content = splitNewContent[0] + (TAG_PASSWORD_BEGIN + TAG_PASSWORD_END) + splitNewContent[2];
+                        this.content = splitNewContent[0]
+                                + (PasswordTagUtil.TAG_PASSWORD_BEGIN + PasswordTagUtil.TAG_PASSWORD_END) + splitNewContent[2];
                     }
 
-                    this.maskedContent = hidePassword(content);
+                    this.maskedContent = PasswordTagUtil.hidePassword(content);
                 }
             } else {
                 this.content = newContent;
-                this.maskedContent = hidePassword(content);
+                this.maskedContent = PasswordTagUtil.hidePassword(content);
             }
         }
     }
 
-    private String hidePassword(final String content) {
-        String[] splitByPasswordTag = splitByPasswordTag(content);
-        if (splitByPasswordTag != null) {
-            if (splitByPasswordTag[1].length() > TAG_PASSWORD_BEGIN.length() + TAG_PASSWORD_END.length()) {
-                return splitByPasswordTag[0] + (TAG_PASSWORD_BEGIN + MASKCODE + TAG_PASSWORD_END) + splitByPasswordTag[2];
+    public static class PasswordTagUtil {
+
+        public static final String TAG_PASSWORD_BEGIN = "<password>";
+
+        public static final String TAG_PASSWORD_END = "</password>";
+
+        public static final String MASKCODE_CHAR = "*";
+
+        public static final String MASKCODE = "******";
+
+        public static String hidePassword(final String content) {
+            String[] splitByPasswordTag = splitByPasswordTag(content);
+            if (splitByPasswordTag != null) {
+                if (splitByPasswordTag[1].length() > TAG_PASSWORD_BEGIN.length() + TAG_PASSWORD_END.length()) {
+                    return splitByPasswordTag[0] + (TAG_PASSWORD_BEGIN + MASKCODE + TAG_PASSWORD_END) + splitByPasswordTag[2];
+                }
+
+                return splitByPasswordTag[0] + (TAG_PASSWORD_BEGIN + TAG_PASSWORD_END) + splitByPasswordTag[2];
             }
 
-            return splitByPasswordTag[0] + (TAG_PASSWORD_BEGIN + TAG_PASSWORD_END) + splitByPasswordTag[2];
+            return content;
         }
 
-        return content;
-    }
+        public static boolean isPasswordHidden(final String content) {
+            String[] splitByPasswordTag = splitByPasswordTag(content);
+            if (splitByPasswordTag != null) {
+                return splitByPasswordTag[1].contains(MASKCODE_CHAR);
+            }
 
-    private boolean isPasswordHidden(final String content) {
-        String[] splitByPasswordTag = splitByPasswordTag(content);
-        if (splitByPasswordTag != null) {
-            return splitByPasswordTag[1].contains(MASKCODE_CHAR);
+            return false;
         }
 
-        return false;
-    }
+        /*
+         * @param newcontent password is mask coded
+         * 
+         * @param content mask coded or not
+         * 
+         * @return content except password part changed
+         */
+        public static boolean isContentChanged(final String newcontent, String content) {
+            String[] splitByPassword_newcontent = splitByPasswordTag(newcontent);
+            String[] splitByPassword_content = splitByPasswordTag(content);
 
-    private boolean contentChanged(final String newcontent) {
-        String[] splitByPassword_newcontent = splitByPasswordTag(newcontent);
-        String[] splitByPassword_maskcontent = splitByPasswordTag(maskedContent);
+            if (splitByPassword_newcontent != null && splitByPassword_content != null) {
+                return !(splitByPassword_newcontent[0].equals(splitByPassword_content[0])
+                        && splitByPassword_newcontent[2].equals(splitByPassword_content[2]));
+            }
 
-        if(splitByPassword_newcontent != null && splitByPassword_maskcontent != null) {
-            return !(splitByPassword_newcontent[0].equals(splitByPassword_maskcontent[0])
-                    && splitByPassword_newcontent[2].equals(splitByPassword_maskcontent[2]));
-        }
-        
-        return true;
-    }
-
-    // No need consider empty tag
-    private String[] splitByPasswordTag(String _content) {
-        int start = _content.indexOf(TAG_PASSWORD_BEGIN);
-        int end = _content.lastIndexOf(TAG_PASSWORD_END) + TAG_PASSWORD_END.length();
-        if (start != -1) {
-            return new String[] { _content.substring(0, start), _content.substring(start, end), _content.substring(end) };
+            return true;
         }
 
-        return null;
+        // No need consider empty tag
+        public static String[] splitByPasswordTag(String _content) {
+            int start = _content.indexOf(TAG_PASSWORD_BEGIN);
+            int end = _content.lastIndexOf(TAG_PASSWORD_END) + TAG_PASSWORD_END.length();
+            if (start != -1) {
+                return new String[] { _content.substring(0, start), _content.substring(start, end), _content.substring(end) };
+            }
+
+            return null;
+        }
     }
 }

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleTextContentEditorPage.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleTextContentEditorPage.java
@@ -53,12 +53,11 @@ public class ExtensibleTextContentEditorPage extends ExtensibleContentEditorPage
     @Override
     public void refresh() {
 
-        if (getCurrentContent().equals(getContent().getContent())) {
+        if (getCurrentContent().equals(getContent().getMaskContent())) {
             return;
         }
 
-        textViewer.setDocument(new Document(getContent().getContent()));
-
+        textViewer.setDocument(new Document(getContent().getMaskContent()));
     }
 
     @Override

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
@@ -24,7 +24,7 @@ public class ExtensibleEditorContentTest {
 
     @Test
     public void testSplitbyPasswordTag() {
-        // check cases:common password, masked password, empty password
+        // check cases:common password, masked password
         String[] checkPasswordPart = { "<password>talend</password>", "<password>******</password>",
                 "<password>*talend</password>", "<password></password>" };
         String[] expectedPasswordPart = { "<password>talend</password>", "<password>******</password>",

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
@@ -1,0 +1,49 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package com.amalto.workbench.widgets.xmleditor;
+
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ExtensibleEditorContentTest {
+
+    @Test
+    public void testSplitbyPasswordTag() {
+        String content = "<parameters>\r\n" + "  <processId>Product_Product</processId>\r\n"
+                + "  <processVersion>1.0</processVersion>\r\n" + "  <username>admin</username>\r\n"
+                + "  <password>talend</password>\r\n" + "  <useBuiltInVariable>false</useBuiltInVariable>\r\n"
+                + "  <defaultDataModel/>\r\n" + "</parameters>";
+
+        String[] expected = new String[] {
+                "<parameters>\r\n" + "  <processId>Product_Product</processId>\r\n" + "  <processVersion>1.0</processVersion>\r\n"
+                        + "  <username>admin</username>\r\n  ",
+                "<password>talend</password>",
+                "\r\n" + "  <useBuiltInVariable>false</useBuiltInVariable>\r\n" + "  <defaultDataModel/>\r\n" + "</parameters>" };
+
+        try {
+            ExtensibleEditorContent extensibleEditorContent = new ExtensibleEditorContent(null);
+            Method declaredMethod = extensibleEditorContent.getClass().getDeclaredMethod("splitbyPasswordTag", String.class);
+            declaredMethod.setAccessible(true);
+            String[] splited = (String[]) declaredMethod.invoke(extensibleEditorContent, content);
+            Assert.assertArrayEquals(expected, splited);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+}

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
@@ -26,9 +26,9 @@ public class ExtensibleEditorContentTest {
     public void testSplitbyPasswordTag() {
         // check cases:common password, masked password, empty password
         String[] checkPasswordPart = { "<password>talend</password>", "<password>******</password>",
-                "<password>*talend</password>", "<password></password>", "<password/>" };
+                "<password>*talend</password>", "<password></password>" };
         String[] expectedPasswordPart = { "<password>talend</password>", "<password>******</password>",
-                "<password>*talend</password>", "<password></password>", "<password/>" };
+                "<password>*talend</password>", "<password></password>" };
         
         String checkContent1 = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
                  
@@ -68,31 +68,10 @@ public class ExtensibleEditorContentTest {
             expected[1] = expectedPasswordPart[0] + pad + expectedPasswordPart[3];
             Assert.assertArrayEquals(expected, splited);
 
-            // empty password tag behind common password tag
-            checkContent = checkContent1 + checkPasswordPart[0] + pad + checkPasswordPart[4] + checkContent2;
+            checkContent = checkContent1 + checkPasswordPart[1] + pad + checkPasswordPart[3] + checkContent2;
             splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = expectedPasswordPart[0];
-            Assert.assertArrayEquals(new String[] { expected[0], expected[1], pad + expectedPasswordPart[4] + expected[2] },
-                    splited);
-
-            // empty password tag before common password tag
-            checkContent = checkContent1 + checkPasswordPart[4] + pad + checkPasswordPart[0] + checkContent2;
-            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = expectedPasswordPart[0];
-            Assert.assertArrayEquals(new String[] { expected[0] + checkPasswordPart[4] + pad, expected[1], expected[2] },
-                    splited);
-
-            checkContent = checkContent1 + checkPasswordPart[4] + pad + checkPasswordPart[3] + checkContent2;
-            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = expectedPasswordPart[3];
-            Assert.assertArrayEquals(new String[] { expected[0] + checkPasswordPart[4] + pad, expected[1], expected[2] },
-                    splited);
-
-            checkContent = checkContent1 + checkPasswordPart[4] + pad + checkPasswordPart[4] + checkContent2;
-            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = checkPasswordPart[4] + pad + checkPasswordPart[4];
+            expected[1] = expectedPasswordPart[1] + pad + expectedPasswordPart[3];
             Assert.assertArrayEquals(expected, splited);
-
         } catch (Exception e) {
             fail();
         }

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
@@ -24,23 +24,75 @@ public class ExtensibleEditorContentTest {
 
     @Test
     public void testSplitbyPasswordTag() {
-        String content = "<parameters>\r\n" + "  <processId>Product_Product</processId>\r\n"
-                + "  <processVersion>1.0</processVersion>\r\n" + "  <username>admin</username>\r\n"
-                + "  <password>talend</password>\r\n" + "  <useBuiltInVariable>false</useBuiltInVariable>\r\n"
-                + "  <defaultDataModel/>\r\n" + "</parameters>";
+        // check cases:common password, masked password, empty password
+        String[] checkPasswordPart = { "<password>talend</password>", "<password>******</password>",
+                "<password>*talend</password>", "<password></password>", "<password/>" };
+        String[] expectedPasswordPart = { "<password>talend</password>", "<password>******</password>",
+                "<password>*talend</password>", "<password></password>", "<password/>" };
+        
+        String checkContent1 = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
+                 
+        String checkContent2 = "\r\n  <useBuiltInVariable>false</useBuiltInVariable>\r\n  <defaultDataModel/>\r\n</parameters>";
 
-        String[] expected = new String[] {
-                "<parameters>\r\n" + "  <processId>Product_Product</processId>\r\n" + "  <processVersion>1.0</processVersion>\r\n"
-                        + "  <username>admin</username>\r\n  ",
-                "<password>talend</password>",
-                "\r\n" + "  <useBuiltInVariable>false</useBuiltInVariable>\r\n" + "  <defaultDataModel/>\r\n" + "</parameters>" };
+        String[] expected = new String[3];
+        expected[0] = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
+        expected[2] = "\r\n  <useBuiltInVariable>false</useBuiltInVariable>\r\n  <defaultDataModel/>\r\n</parameters>";
+
+        String pad = "<desc>abc</desc>";
 
         try {
             ExtensibleEditorContent extensibleEditorContent = new ExtensibleEditorContent(null);
-            Method declaredMethod = extensibleEditorContent.getClass().getDeclaredMethod("splitbyPasswordTag", String.class);
+            Method declaredMethod = extensibleEditorContent.getClass().getDeclaredMethod("splitByPasswordTag", String.class);
             declaredMethod.setAccessible(true);
-            String[] splited = (String[]) declaredMethod.invoke(extensibleEditorContent, content);
+
+            // check every single password
+            for (int i = 0; i < checkPasswordPart.length; i++) {
+                String checkContent = checkContent1 + checkPasswordPart[i] + checkContent2;
+                String[] splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+                expected[1] = expectedPasswordPart[i];
+                Assert.assertArrayEquals(expected, splited);
+            }
+
+            // check case: no password part
+            String[] splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent1 + checkContent2);
+            Assert.assertArrayEquals(null, splited);
+
+            // check invalid content: multi password tag
+            String checkContent = checkContent1 + checkPasswordPart[0] + pad + checkPasswordPart[1] + checkContent2;
+            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+            expected[1] = expectedPasswordPart[0] + pad + expectedPasswordPart[1];
             Assert.assertArrayEquals(expected, splited);
+
+            checkContent = checkContent1 + checkPasswordPart[0] + pad + checkPasswordPart[3] + checkContent2;
+            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+            expected[1] = expectedPasswordPart[0] + pad + expectedPasswordPart[3];
+            Assert.assertArrayEquals(expected, splited);
+
+            // empty password tag behind common password tag
+            checkContent = checkContent1 + checkPasswordPart[0] + pad + checkPasswordPart[4] + checkContent2;
+            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+            expected[1] = expectedPasswordPart[0];
+            Assert.assertArrayEquals(new String[] { expected[0], expected[1], pad + expectedPasswordPart[4] + expected[2] },
+                    splited);
+
+            // empty password tag before common password tag
+            checkContent = checkContent1 + checkPasswordPart[4] + pad + checkPasswordPart[0] + checkContent2;
+            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+            expected[1] = expectedPasswordPart[0];
+            Assert.assertArrayEquals(new String[] { expected[0] + checkPasswordPart[4] + pad, expected[1], expected[2] },
+                    splited);
+
+            checkContent = checkContent1 + checkPasswordPart[4] + pad + checkPasswordPart[3] + checkContent2;
+            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+            expected[1] = expectedPasswordPart[3];
+            Assert.assertArrayEquals(new String[] { expected[0] + checkPasswordPart[4] + pad, expected[1], expected[2] },
+                    splited);
+
+            checkContent = checkContent1 + checkPasswordPart[4] + pad + checkPasswordPart[4] + checkContent2;
+            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
+            expected[1] = checkPasswordPart[4] + pad + checkPasswordPart[4];
+            Assert.assertArrayEquals(expected, splited);
+
         } catch (Exception e) {
             fail();
         }

--- a/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
+++ b/test/plugins/org.talend.mdm.workbench.test/src/main/java/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContentTest.java
@@ -14,20 +14,100 @@ package com.amalto.workbench.widgets.xmleditor;
 
 import static org.junit.Assert.fail;
 
-import java.lang.reflect.Method;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.amalto.workbench.widgets.xmleditor.ExtensibleEditorContent.PasswordTagUtil;
 
 
 public class ExtensibleEditorContentTest {
 
     @Test
+    public void testHidePassword() {
+        // check cases:common password, masked password,empty password
+        String[] passwordPart = { "<password>talend</password>", "<password>******</password>", "<password>*talend</password>",
+                "<password></password>", "<password/>" };
+        String[] expectedPasswordPart = { "<password>******</password>", "<password>******</password>",
+                "<password>******</password>", "<password></password>", "<password/>" };
+
+        String checkContent1 = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
+
+        String checkContent2 = "\r\n  <useBuiltInVariable>false</useBuiltInVariable>\r\n  <defaultDataModel/>\r\n</parameters>";
+
+        for (int i = 0; i < passwordPart.length; i++) {
+            String expected = checkContent1 + expectedPasswordPart[i] + checkContent2;
+            String hidePassword = PasswordTagUtil.hidePassword(checkContent1 + passwordPart[i] + checkContent2);
+            Assert.assertEquals(expected, hidePassword);
+        }
+    }
+
+    @Test
+    public void testIsPasswordHidden() {
+        // check cases:common password, masked password,empty password
+        String[] passwordPart = { "<password>talend</password>", "<password>******</password>", "<password>*talend</password>",
+                "<password></password>", "<password/>" };
+        boolean[] expected = { false, true, true, false, false };
+
+        String checkContent1 = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
+
+        String checkContent2 = "\r\n  <useBuiltInVariable>false</useBuiltInVariable>\r\n  <defaultDataModel/>\r\n</parameters>";
+
+        for (int i = 0; i < passwordPart.length; i++) {
+            boolean hidePassword = PasswordTagUtil.isPasswordHidden(checkContent1 + passwordPart[i] + checkContent2);
+            Assert.assertEquals(expected[i], hidePassword);
+        }
+    }
+
+    @Test
+    public void testIsContentChanged() {
+        String[] newpasswordPart = { "<password>******</password>", "<password>*talend*</password>",
+                "<password>*talend*</password>", "<password>*talend</password>", "<password>******</password>",
+                "<password>******</password>", "<password>*talend*</password>" };
+        String[] passwordPart = { "<password>******</password>", "<password>*talend*</password>", "<password>tal*end*</password>",
+                "<password>******</password>", "<password>tal*end*</password>", "<password></password>",
+                "<password></password>" };
+        String pad = "<desc>abc</desc>";
+
+        String checkContent1 = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
+
+        String checkContent2 = "\r\n  <useBuiltInVariable>false</useBuiltInVariable>\r\n  <defaultDataModel/>\r\n</parameters>";
+
+        // only mask coded password changed
+        for (int i = 0; i < newpasswordPart.length; i++) {
+            boolean contentChanged = PasswordTagUtil.isContentChanged(checkContent1 + newpasswordPart[i] + checkContent2,
+                    checkContent1 + passwordPart[i] + checkContent2);
+            Assert.assertEquals(false, contentChanged);
+        }
+
+        newpasswordPart = new String[] { "<password>*talend</password>", "<password>******</password>" };
+        passwordPart = new String[] { "<password/>", "<password/>" };
+        for (int i = 0; i < newpasswordPart.length; i++) {
+            boolean contentChanged = PasswordTagUtil.isContentChanged(checkContent1 + newpasswordPart[i] + checkContent2,
+                    checkContent1 + passwordPart[i] + checkContent2);
+            Assert.assertEquals(true, contentChanged);
+        }
+
+        // except mask code password changed , other content also changed
+        for (int i = 0; i < newpasswordPart.length; i++) {
+            boolean contentChanged1 = PasswordTagUtil.isContentChanged(checkContent1 + newpasswordPart[i] + checkContent2 + pad,
+                    checkContent1 + passwordPart[i] + checkContent2);
+            boolean contentChanged2 = PasswordTagUtil.isContentChanged(checkContent1 + newpasswordPart[i] + pad + checkContent2,
+                    checkContent1 + passwordPart[i] + checkContent2);
+            boolean contentChanged3 = PasswordTagUtil.isContentChanged(checkContent1 + pad + newpasswordPart[i] + checkContent2,
+                    checkContent1 + passwordPart[i] + checkContent2);
+            boolean contentChanged4 = PasswordTagUtil.isContentChanged(pad + checkContent1 + newpasswordPart[i] + checkContent2,
+                    checkContent1 + passwordPart[i] + checkContent2);
+            Assert.assertEquals(true, contentChanged1);
+            Assert.assertEquals(true, contentChanged2);
+            Assert.assertEquals(true, contentChanged3);
+            Assert.assertEquals(true, contentChanged4);
+        }
+    }
+
+    @Test
     public void testSplitbyPasswordTag() {
         // check cases:common password, masked password
-        String[] checkPasswordPart = { "<password>talend</password>", "<password>******</password>",
-                "<password>*talend</password>", "<password></password>" };
-        String[] expectedPasswordPart = { "<password>talend</password>", "<password>******</password>",
+        String[] passwordPart = { "<password>talend</password>", "<password>******</password>",
                 "<password>*talend</password>", "<password></password>" };
         
         String checkContent1 = "<parameters>\r\n  <processId>Product_Product</processId>\r\n  <processVersion>1.0</processVersion>\r\n  <username>admin</username>\r\n  ";
@@ -41,36 +121,32 @@ public class ExtensibleEditorContentTest {
         String pad = "<desc>abc</desc>";
 
         try {
-            ExtensibleEditorContent extensibleEditorContent = new ExtensibleEditorContent(null);
-            Method declaredMethod = extensibleEditorContent.getClass().getDeclaredMethod("splitByPasswordTag", String.class);
-            declaredMethod.setAccessible(true);
-
             // check every single password
-            for (int i = 0; i < checkPasswordPart.length; i++) {
-                String checkContent = checkContent1 + checkPasswordPart[i] + checkContent2;
-                String[] splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-                expected[1] = expectedPasswordPart[i];
+            for (int i = 0; i < passwordPart.length; i++) {
+                String checkContent = checkContent1 + passwordPart[i] + checkContent2;
+                String[] splited = PasswordTagUtil.splitByPasswordTag(checkContent);
+                expected[1] = passwordPart[i];
                 Assert.assertArrayEquals(expected, splited);
             }
 
             // check case: no password part
-            String[] splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent1 + checkContent2);
+            String[] splited = PasswordTagUtil.splitByPasswordTag(checkContent1 + checkContent2);
             Assert.assertArrayEquals(null, splited);
 
             // check invalid content: multi password tag
-            String checkContent = checkContent1 + checkPasswordPart[0] + pad + checkPasswordPart[1] + checkContent2;
-            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = expectedPasswordPart[0] + pad + expectedPasswordPart[1];
+            String checkContent = checkContent1 + passwordPart[0] + pad + passwordPart[1] + checkContent2;
+            splited = PasswordTagUtil.splitByPasswordTag(checkContent);
+            expected[1] = passwordPart[0] + pad + passwordPart[1];
             Assert.assertArrayEquals(expected, splited);
 
-            checkContent = checkContent1 + checkPasswordPart[0] + pad + checkPasswordPart[3] + checkContent2;
-            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = expectedPasswordPart[0] + pad + expectedPasswordPart[3];
+            checkContent = checkContent1 + passwordPart[0] + pad + passwordPart[3] + checkContent2;
+            splited = PasswordTagUtil.splitByPasswordTag(checkContent);
+            expected[1] = passwordPart[0] + pad + passwordPart[3];
             Assert.assertArrayEquals(expected, splited);
 
-            checkContent = checkContent1 + checkPasswordPart[1] + pad + checkPasswordPart[3] + checkContent2;
-            splited = (String[]) declaredMethod.invoke(extensibleEditorContent, checkContent);
-            expected[1] = expectedPasswordPart[1] + pad + expectedPasswordPart[3];
+            checkContent = checkContent1 + passwordPart[1] + pad + passwordPart[3] + checkContent2;
+            splited = PasswordTagUtil.splitByPasswordTag(checkContent);
+            expected[1] = passwordPart[1] + pad + passwordPart[3];
             Assert.assertArrayEquals(expected, splited);
         } catch (Exception e) {
             fail();


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-14523
Password still show in source editor for workflow & workflowcontext service jndi name, or for workflowtrigger & workflowcontexttrigger plugin for process.

**What is the new behavior?**
Hide password in source editor. But allow user edit all parameters in source editor, if changed password contains * , all other changed parameters exception password will be saved.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
