### PR TITLE
TMDM-13735 Studio JUnit enhancement to remove Powermock

### DIFF
--- a/test/plugins/org.talend.mdm.repository.test/src/main/java/org/talend/mdm/repository/core/service/ContainerCacheServiceTest.java
+++ b/test/plugins/org.talend.mdm.repository.test/src/main/java/org/talend/mdm/repository/core/service/ContainerCacheServiceTest.java
@@ -102,15 +102,20 @@ public class ContainerCacheServiceTest {
         assertEquals(mockViewObj, ContainerCacheService.get(propId));
 
         ContainerCacheService.clearCache();
+
+        Map<Class<?>, AbstractDQModelService> dqModelServices = null;
+        Map<Class, IService> services = null;
+        IProxyRepositoryService originRepoService = null;
+        AbstractDQModelService originDQService = null;
         try {
             Field declaredField = GlobalServiceRegister.class.getDeclaredField("dqModelServices");
             declaredField.setAccessible(true);
-            Map<Class<?>, AbstractDQModelService> map = (Map<Class<?>, AbstractDQModelService>) declaredField
-                    .get(GlobalServiceRegister.getDefault());
+            dqModelServices = (Map<Class<?>, AbstractDQModelService>) declaredField.get(GlobalServiceRegister.getDefault());
             AbstractDQModelService mockDQService = Mockito.mock(AbstractDQModelService.class);
             Mockito.when(mockDQService.getTDQRepObjType(any(Item.class)))
                     .thenReturn(IServerObjectRepositoryType.TYPE_CUSTOM_FORM);
-            map.put(AbstractDQModelService.class, mockDQService);
+            originDQService = dqModelServices.get(AbstractDQModelService.class);
+            dqModelServices.put(AbstractDQModelService.class, mockDQService);
 
             Field serviceField = GlobalServiceRegister.class.getDeclaredField("services");
             serviceField.setAccessible(true);
@@ -118,7 +123,8 @@ public class ContainerCacheServiceTest {
             IProxyRepositoryFactory mockFactory = Mockito.mock(IProxyRepositoryFactory.class);
             Mockito.when(mockRepoService.getProxyRepositoryFactory()).thenReturn(mockFactory);
 
-            Map<Class, IService> services = (Map<Class, IService>) serviceField.get(GlobalServiceRegister.getDefault());
+            services = (Map<Class, IService>) serviceField.get(GlobalServiceRegister.getDefault());
+            originRepoService = (IProxyRepositoryService) dqModelServices.get(IProxyRepositoryService.class);
             services.put(IProxyRepositoryService.class, mockRepoService);
 
             ItemState mockItemState = Mockito.mock(ItemState.class);
@@ -132,6 +138,13 @@ public class ContainerCacheServiceTest {
             assertTrue(ContainerCacheService.get(propId) != null);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
+        } finally {
+            if (dqModelServices != null) {
+                dqModelServices.put(AbstractDQModelService.class, originDQService);
+            }
+            if (services != null) {
+                services.put(IProxyRepositoryService.class, originRepoService);
+            }
         }
     }
 
@@ -154,15 +167,19 @@ public class ContainerCacheServiceTest {
 
         ContainerCacheService.clearCache();
         //
+        Map<Class<?>, AbstractDQModelService> dqModelServices = null;
+        Map<Class, IService> services = null;
+        IProxyRepositoryService originRepoService = null;
+        AbstractDQModelService originDQService = null;
         try {
             Field declaredField = GlobalServiceRegister.class.getDeclaredField("dqModelServices");
             declaredField.setAccessible(true);
-            Map<Class<?>, AbstractDQModelService> map = (Map<Class<?>, AbstractDQModelService>) declaredField
-                    .get(GlobalServiceRegister.getDefault());
+            dqModelServices = (Map<Class<?>, AbstractDQModelService>) declaredField.get(GlobalServiceRegister.getDefault());
             AbstractDQModelService mockDQService = Mockito.mock(AbstractDQModelService.class);
             Mockito.when(mockDQService.getTDQRepObjType(any(Item.class)))
                     .thenReturn(IServerObjectRepositoryType.TYPE_CUSTOM_FORM);
-            map.put(AbstractDQModelService.class, mockDQService);
+            originDQService = dqModelServices.get(AbstractDQModelService.class);
+            dqModelServices.put(AbstractDQModelService.class, mockDQService);
 
             Field serviceField = GlobalServiceRegister.class.getDeclaredField("services");
             serviceField.setAccessible(true);
@@ -170,7 +187,8 @@ public class ContainerCacheServiceTest {
             IProxyRepositoryFactory mockFactory = Mockito.mock(IProxyRepositoryFactory.class);
             Mockito.when(mockRepoService.getProxyRepositoryFactory()).thenReturn(mockFactory);
 
-            Map<Class, IService> services = (Map<Class, IService>) serviceField.get(GlobalServiceRegister.getDefault());
+            services = (Map<Class, IService>) serviceField.get(GlobalServiceRegister.getDefault());
+            originRepoService = (IProxyRepositoryService) services.get(IProxyRepositoryService.class);
             services.put(IProxyRepositoryService.class, mockRepoService);
 
             Property mockProp = Mockito.mock(Property.class);
@@ -190,6 +208,13 @@ public class ContainerCacheServiceTest {
             assertTrue(ContainerCacheService.get(propId) != null);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
+        } finally {
+            if (dqModelServices != null) {
+                dqModelServices.put(AbstractDQModelService.class, originDQService);
+            }
+            if (services != null) {
+                services.put(IProxyRepositoryService.class, originRepoService);
+            }
         }
     }
 


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-13735
set mock object into global registered service may affect other test if does not recover.

**What is the new behavior?**
Recover the global registered service after set mock object into.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:
workitem
**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
