### PR TITLE
TUP-27716 Make sure authorization works when username/password contains special words.

### DIFF
--- a/main/plugins/org.talend.mdm.workbench.serverexplorer/src/main/java/org/talend/mdm/workbench/serverexplorer/console/MDMServerMessageConsole.java
+++ b/main/plugins/org.talend.mdm.workbench.serverexplorer/src/main/java/org/talend/mdm/workbench/serverexplorer/console/MDMServerMessageConsole.java
@@ -336,6 +336,7 @@ public abstract class MDMServerMessageConsole extends MessageConsole implements 
 
     private HttpResponse executeByHttpget(String url, String userName, String password) {
         HttpGet httpGet = new HttpGet(url);
+        HttpClientUtil.wrapHttpRequest(httpGet, userName, password);
         HttpClientUtil.addStudioToken(httpGet, serverDef.getUser());
         DefaultHttpClient httpClient = createHttpClient();
 

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/HttpClientUtil.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/HttpClientUtil.java
@@ -99,7 +99,7 @@ public class HttpClientUtil {
         return new DefaultHttpClient(cm, params);
     }
 
-    private static void wrapHttpRequest(HttpUriRequest httpRequest, String username, String password) {
+    public static void wrapHttpRequest(HttpUriRequest httpRequest, String username, String password) {
         try {
             byte[] authBytes = (username + ":" + password).getBytes("UTF-8");
             String authString = Base64.getEncoder().encodeToString(authBytes);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TUP-27716

**What is the current behavior?** (You should also link to an open issue here)
View server log/view server match log does not work if username/password contains special words.


**What is the new behavior?**
View server log/view server match log work when username/password contains special words.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
