### PR TITLE
TMDM-14772 Replace toLowerCase().equals() with equalsIgnoreCase

### DIFF
--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/service/wsimpl/transformplugin/CodeProjectPluginDetail.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/service/wsimpl/transformplugin/CodeProjectPluginDetail.java
@@ -43,7 +43,7 @@ public class CodeProjectPluginDetail extends AbstractPluginDetail {
 
     public String getDescription() {
         String description = ""; //$NON-NLS-1$
-        if (twoLettersLanguageCode.toLowerCase().equals("en")) { //$NON-NLS-1$
+        if (twoLettersLanguageCode.equalsIgnoreCase("en")) { //$NON-NLS-1$
             description = Messages.CodeProjectXX_PluginUsedText;
         } else {
             description = Messages.BatchProjectXX_UNSupportedLan;

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/service/wsimpl/transformplugin/DumpAndGoPluginDetail.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/service/wsimpl/transformplugin/DumpAndGoPluginDetail.java
@@ -44,7 +44,7 @@ public class DumpAndGoPluginDetail extends AbstractPluginDetail {
     public String getDescription() {
 
         String description = ""; //$NON-NLS-1$
-        if (twoLettersLanguageCode.toLowerCase().equals("en")) { //$NON-NLS-1$
+        if (twoLettersLanguageCode.equalsIgnoreCase("en")) { //$NON-NLS-1$
             description = Messages.DumpAndGoPluginDetail_PlugDesc;
         } else {
             description = Messages.BatchProjectXX_UNSupportedLan;

--- a/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/service/wsimpl/transformplugin/GroovyPluginDetail.java
+++ b/main/plugins/org.talend.mdm.repository/src/main/java/org/talend/mdm/repository/core/service/wsimpl/transformplugin/GroovyPluginDetail.java
@@ -43,7 +43,7 @@ public class GroovyPluginDetail extends AbstractPluginDetail {
 
     public String getDescription() {
         String description = ""; //$NON-NLS-1$
-        if (twoLettersLanguageCode.toLowerCase().equals("en")) { //$NON-NLS-1$
+        if (twoLettersLanguageCode.equalsIgnoreCase("en")) { //$NON-NLS-1$
             description = Messages.GroovyPluginDetail_PluginCallScript;
         } else {
             description = Messages.BatchProjectXX_UNSupportedLan;

--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XmlUtil.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/XmlUtil.java
@@ -211,10 +211,10 @@ public final class XmlUtil {
 
         OutputFormat format = null;
 
-        if (printMode.toLowerCase().equals("pretty")) {//$NON-NLS-1$
+        if (printMode.equalsIgnoreCase("pretty")) {//$NON-NLS-1$
             // Pretty print the document
             format = OutputFormat.createPrettyPrint();
-        } else if (printMode.toLowerCase().equals("compact")) {//$NON-NLS-1$
+        } else if (printMode.equalsIgnoreCase("compact")) {//$NON-NLS-1$
             // Compact format
             format = OutputFormat.createCompactFormat();
         }


### PR DESCRIPTION
There are a some instances in the code where toLowerCase().equals() is used, when equalsIgnoreCase() would suffice. The latter is more concise + also doesn't involve the default Locale that's used with toLowerCase(), which might be problematic depending on the String being compared.