### PR TITLE
feat(TUP-28521) fix problem that plugin editor can't show content for plugins.

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/widgets/xmleditor/ExtensibleEditorContent.java
@@ -19,9 +19,7 @@ public class ExtensibleEditorContent {
     private String maskedContent;
 
     public ExtensibleEditorContent(String content) {
-
-        if (content != null)
-            this.content = content;
+        setContent(content);
     }
 
     public String getContent() {
@@ -37,6 +35,7 @@ public class ExtensibleEditorContent {
             this.content = "";//$NON-NLS-1$
             this.maskedContent = "";
         } else {
+            this.content = newContent;
             if (PasswordTagUtil.isPasswordHidden(newContent)) {
                 if (PasswordTagUtil.isContentChanged(newContent, maskedContent)) {
                     String[] splitNewContent = PasswordTagUtil.splitByPasswordTag(newContent);
@@ -53,7 +52,6 @@ public class ExtensibleEditorContent {
                     this.maskedContent = PasswordTagUtil.hidePassword(content);
                 }
             } else {
-                this.content = newContent;
                 this.maskedContent = PasswordTagUtil.hidePassword(content);
             }
         }


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TUP-28521
the plugin parameters of plugin type xslt, codec, regexp, replace.... can't be displayed in the editor for process.

**What is the new behavior?**
the plugin parameters of plugin type  xslt, codec, regexp, replace.... can be displayed in the editor for process.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
