### PR TITLE
fix(TUP-29347) fix displace resource node error during importing server objects.

### DIFF
--- a/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/LocalTreeObjectRepository.java
+++ b/main/plugins/org.talend.mdm.workbench/src/com/amalto/workbench/utils/LocalTreeObjectRepository.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -528,7 +529,7 @@ public class LocalTreeObjectRepository implements IXObjectModelListener, ITreeVi
     private String synchronizeWithElem(TreeObject theObj, TreeParent folder, boolean fireEvent) {
         internalCheck = fireEvent;
         String catalogPath = "";//$NON-NLS-1$
-        ArrayList<String> catalogs = checkUpCatalogRepositoryForTreeObject(theObj, folder);
+        List<String> catalogs = checkUpCatalogRepositoryForTreeObject(theObj, folder);
         if (catalogs != null && folder.getType() != TreeObject.CATEGORY_FOLDER) {
             // create a catalog folder and insert the theObj into it
             TreeParent subFolder = folder;
@@ -648,8 +649,13 @@ public class LocalTreeObjectRepository implements IXObjectModelListener, ITreeVi
 
         if (theObj instanceof TreeParent) {
             TreeParent subParent = (TreeParent) theObj;
-            for (TreeObject obj : subParent.getChildren()) {
-                synchronizeWithElem(obj, subParent, fireEvent);
+            TreeObject[] children = subParent.getChildren();
+            if (children != null) {
+                new Thread() {// handle if big amount data
+                    public void run() {
+                        Stream.of(children).parallel().forEach(treeobj -> synchronizeWithElem(treeobj, subParent, fireEvent));
+                    };
+                }.start();
             }
         }
 
@@ -810,7 +816,7 @@ public class LocalTreeObjectRepository implements IXObjectModelListener, ITreeVi
         accommodations.clear();
     }
 
-    private ArrayList<String> checkUpCatalogRepositoryForTreeObject(TreeObject theObj, TreeObject folder) {
+    private List<String> checkUpCatalogRepositoryForTreeObject(TreeObject theObj, TreeObject folder) {
         if (theObj.getType() == 0 || theObj.getType() == TreeObject.CATEGORY_FOLDER) {
             return null;
         }
@@ -832,7 +838,7 @@ public class LocalTreeObjectRepository implements IXObjectModelListener, ITreeVi
                 }
                 if (elem.getName().equals(filterOutBlank(theObj.getDisplayName()))
                         && elem.getData().toString().equals(theObj.getType() + "")) {//$NON-NLS-1$
-                    ArrayList<String> path = new ArrayList<String>();
+                    List<String> path = new ArrayList<String>();
                     HashMap<Integer, String> slice = new HashMap<Integer, String>();
                     while (isAEXtentisObjects(elem, theObj) > XTENTIS_LEVEL) {
                         String elemName = elem.getParent().getName();
@@ -850,7 +856,7 @@ public class LocalTreeObjectRepository implements IXObjectModelListener, ITreeVi
                         elem = elem.getParent();
                     }
 
-                    ArrayList<String> pathCpy = new ArrayList<String>(path);
+                    List<String> pathCpy = new ArrayList<String>(path);
                     Collections.reverse(path);
                     if (!isEqualString(xpathElem, xpathObj, path)) {
                         path = null;
@@ -874,9 +880,9 @@ public class LocalTreeObjectRepository implements IXObjectModelListener, ITreeVi
         return null;
     }
 
-    private boolean isEqualString(String xpathElem, String xpathObj, ArrayList<String> catalogs) {
-        ArrayList<String> elems = new ArrayList<String>(Arrays.asList(xpathElem.split("/")));//$NON-NLS-1$
-        ArrayList<String> objs = new ArrayList<String>(Arrays.asList(xpathObj.split("/")));//$NON-NLS-1$
+    private boolean isEqualString(String xpathElem, String xpathObj, List<String> catalogs) {
+        List<String> elems = new ArrayList<String>(Arrays.asList(xpathElem.split("/")));//$NON-NLS-1$
+        List<String> objs = new ArrayList<String>(Arrays.asList(xpathObj.split("/")));//$NON-NLS-1$
         int orgSize = objs.size();
         for (int i = 0; i < objs.size(); i++) {
             if (!objs.get(i).equals(elems.get(i))) {


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29347
"Import Server Objects from MDM server" hangs consuming high CPU when resources contains more data.(like 100 thousands records).

**What is the new behavior?**
"Import Server Objects from MDM server" will finish in minutes when resources contains more data records.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
